### PR TITLE
feat(ebuild): implement EAPI 8 support (v0.3.0-002)

### DIFF
--- a/internal/ebuild/environment.go
+++ b/internal/ebuild/environment.go
@@ -104,6 +104,10 @@ type Environment struct {
 
 	// EBUILD = path to the ebuild file being executed
 	EBUILD string
+
+	// ExtraVars holds additional environment variables set by ebuilds.
+	// This includes ebuild-specific variables like DOCS, HTML_DOCS, etc.
+	ExtraVars map[string]string
 }
 
 // NewEnvironment creates a new ebuild execution environment.
@@ -266,4 +270,36 @@ func (env *Environment) Cleanup() error {
 	// Remove work base directory
 	workBase := filepath.Dir(env.WORKDIR)
 	return os.RemoveAll(workBase)
+}
+
+// GetVar retrieves an environment variable by name.
+//
+// First checks built-in variables (P, PN, PV, etc.), then checks ExtraVars.
+// Returns empty string if not found.
+func (env *Environment) GetVar(name string) string {
+	// Use ToMap to get all built-in variables
+	builtIn := env.ToMap()
+	if val, ok := builtIn[name]; ok {
+		return val
+	}
+
+	// Check ExtraVars
+	if env.ExtraVars != nil {
+		if val, ok := env.ExtraVars[name]; ok {
+			return val
+		}
+	}
+
+	return ""
+}
+
+// SetVar sets an extra environment variable.
+//
+// Built-in variables cannot be set via this method.
+// Use this for ebuild-specific variables like DOCS, HTML_DOCS, etc.
+func (env *Environment) SetVar(name, value string) {
+	if env.ExtraVars == nil {
+		env.ExtraVars = make(map[string]string)
+	}
+	env.ExtraVars[name] = value
 }

--- a/internal/ebuild/helpers.go
+++ b/internal/ebuild/helpers.go
@@ -73,6 +73,10 @@ type Helpers struct {
 
 	// Package database for has_version/best_version queries
 	pkgDB *state.PackageDatabase
+
+	// Strip control (EAPI 8)
+	stripInclude []string // Paths to include in stripping
+	stripExclude []string // Paths to exclude from stripping (-x flag)
 }
 
 // NewHelpers creates helpers instance with default settings.

--- a/internal/ebuild/helpers_doc.go
+++ b/internal/ebuild/helpers_doc.go
@@ -1,6 +1,6 @@
 // Package ebuild implements ebuild execution engine.
 //
-// This file provides EAPI 8 documentation functions (dodoc, doman, newdoc, newman).
+// This file provides EAPI 8 documentation functions (dodoc, doman, newdoc, newman, einstalldocs).
 package ebuild
 
 import (
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // ============================================================================
@@ -199,4 +200,164 @@ func (h *Helpers) Newman(args []string) error {
 	}
 
 	return nil
+}
+
+// ============================================================================
+// EAPI 8 Standard Documentation Installation
+// ============================================================================
+
+// standardDocPatterns contains the standard documentation file patterns
+// that einstalldocs looks for. Per PMS Section 11.3.3.20.
+var standardDocPatterns = []string{
+	"README",
+	"README.*",
+	"README.md",
+	"README.rst",
+	"README.txt",
+	"CHANGELOG",
+	"CHANGELOG.*",
+	"ChangeLog",
+	"ChangeLog.*",
+	"CHANGES",
+	"CHANGES.*",
+	"AUTHORS",
+	"AUTHORS.*",
+	"NEWS",
+	"NEWS.*",
+	"TODO",
+	"TODO.*",
+	"COPYING",
+	"COPYING.*",
+	"LICENSE",
+	"LICENSE.*",
+	"LICENSE-*",
+	"HACKING",
+	"HACKING.*",
+	"MAINTAINERS",
+}
+
+// installDocFiles installs a space-separated list of doc files from a variable.
+// workdir is the base directory for relative paths.
+func (h *Helpers) installDocFiles(docsVar, workdir string) error {
+	for _, f := range strings.Fields(docsVar) {
+		// Handle paths that might be relative or absolute
+		var fullPath string
+		if filepath.IsAbs(f) {
+			fullPath = f
+		} else {
+			fullPath = filepath.Join(workdir, f)
+		}
+
+		// Check if file/directory exists
+		info, err := os.Stat(fullPath)
+		if err != nil {
+			// Skip missing files silently (per Portage behavior)
+			continue
+		}
+
+		if info.IsDir() {
+			// Install directory recursively
+			if err := h.Dodoc([]string{"-r", fullPath}); err != nil {
+				return err
+			}
+		} else {
+			if err := h.Dodoc([]string{fullPath}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// installStandardDocs installs documentation files matching standard patterns.
+func (h *Helpers) installStandardDocs(workdir string) {
+	for _, pattern := range standardDocPatterns {
+		matches, err := filepath.Glob(filepath.Join(workdir, pattern))
+		if err != nil {
+			// Invalid pattern - skip
+			continue
+		}
+
+		for _, match := range matches {
+			info, err := os.Stat(match)
+			if err != nil {
+				continue
+			}
+
+			// Skip directories for simple patterns
+			if info.IsDir() {
+				continue
+			}
+
+			// Install the file
+			if err := h.Dodoc([]string{match}); err != nil {
+				// Log warning but continue with other files
+				h.writeStderr(fmt.Sprintf(">>> einstalldocs: warning: failed to install %s: %v\n",
+					filepath.Base(match), err))
+			}
+		}
+	}
+}
+
+// Einstalldocs installs standard documentation files.
+//
+// Per PMS Section 11.3.3.20 (EAPI 8):
+//   - Looks for standard documentation files in ${S} (source directory)
+//   - Installs found files to ${ED}/usr/share/doc/${PF}/
+//   - Respects the DOCS environment variable if set
+//   - Respects the HTML_DOCS environment variable for HTML documentation
+//
+// Standard files searched:
+//
+//	README*, CHANGELOG*, ChangeLog*, AUTHORS*, NEWS*, TODO*,
+//	COPYING*, LICENSE*, HACKING*, MAINTAINERS
+//
+// Usage: einstalldocs (no arguments)
+//
+// Returns nil on success. Missing files are silently skipped.
+func (h *Helpers) Einstalldocs(args []string) error {
+	// Get the source directory (S)
+	workdir := h.getSourceDir()
+	if workdir == "" {
+		return &DieError{Message: "einstalldocs: S (source directory) not set"}
+	}
+
+	// Install files from DOCS variable if set
+	if h.env != nil {
+		if docsVar := h.env.GetVar("DOCS"); docsVar != "" {
+			if err := h.installDocFiles(docsVar, workdir); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Install standard documentation files
+	h.installStandardDocs(workdir)
+
+	// Handle HTML_DOCS
+	if h.env != nil {
+		if htmlDocsVar := h.env.GetVar("HTML_DOCS"); htmlDocsVar != "" {
+			// Save current docDestTree and set to html/
+			oldDocDestTree := h.docDestTree
+			h.docDestTree = "html"
+			err := h.installDocFiles(htmlDocsVar, workdir)
+			h.docDestTree = oldDocDestTree
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// getSourceDir returns the source directory (S or WORKDIR).
+func (h *Helpers) getSourceDir() string {
+	if h.env == nil {
+		return ""
+	}
+	if h.env.S != "" {
+		return h.env.S
+	}
+	return h.env.WORKDIR
 }

--- a/internal/ebuild/helpers_install.go
+++ b/internal/ebuild/helpers_install.go
@@ -897,15 +897,28 @@ func (h *Helpers) Doenvd(args []string) error {
 // Dosym creates a symbolic link.
 //
 // Usage: dosym target linkname
+// Usage: dosym -r target linkname (EAPI 8: relative symlink)
+//
+// With -r flag (EAPI 8), calculates the relative path from linkname to target
+// automatically. Both paths should be absolute paths within the image.
 //
 // Creates symlink ${D}/${linkname} -> target
 func (h *Helpers) Dosym(args []string) error {
-	if len(args) < 2 {
+	relative := false
+	argIdx := 0
+
+	// Parse -r flag (EAPI 8 feature)
+	if len(args) > 0 && args[0] == "-r" {
+		relative = true
+		argIdx = 1
+	}
+
+	if len(args) < argIdx+2 {
 		return &DieError{Message: "dosym: requires target and linkname"}
 	}
 
-	target := args[0]
-	linkname := args[1]
+	target := args[argIdx]
+	linkname := args[argIdx+1]
 
 	imageDir := h.getImageDir()
 	if imageDir == "" {
@@ -913,6 +926,11 @@ func (h *Helpers) Dosym(args []string) error {
 	}
 
 	linkPath := filepath.Join(imageDir, linkname)
+
+	// For relative symlinks, calculate the relative path from link to target
+	if relative {
+		target = calculateRelativePath(linkname, target)
+	}
 
 	// Create parent directory
 	if err := os.MkdirAll(filepath.Dir(linkPath), 0755); err != nil {
@@ -928,6 +946,41 @@ func (h *Helpers) Dosym(args []string) error {
 	}
 
 	return nil
+}
+
+// calculateRelativePath computes the relative path from linkPath to targetPath.
+//
+// Both paths should be absolute paths (starting with /).
+// Returns a relative path that, when resolved from the link's directory,
+// points to the target.
+//
+// Examples:
+//   - linkPath="/usr/lib/libfoo.so", targetPath="/usr/lib/libfoo.so.1"
+//     returns "libfoo.so.1"
+//   - linkPath="/usr/lib/libfoo.so", targetPath="/usr/lib64/libfoo.so.1"
+//     returns "../lib64/libfoo.so.1"
+//   - linkPath="/usr/bin/python", targetPath="/usr/bin/python3.11"
+//     returns "python3.11"
+func calculateRelativePath(linkPath, targetPath string) string {
+	// Clean both paths
+	linkPath = filepath.Clean(linkPath)
+	targetPath = filepath.Clean(targetPath)
+
+	// Get the directory containing the link
+	linkDir := filepath.Dir(linkPath)
+
+	// Calculate relative path from link directory to target
+	relPath, err := filepath.Rel(linkDir, targetPath)
+	if err != nil {
+		// If we can't compute relative path, return target as-is
+		return targetPath
+	}
+
+	// On Windows, convert backslashes to forward slashes for consistency
+	// (though GRPM targets Linux, this ensures tests work cross-platform)
+	relPath = filepath.ToSlash(relPath)
+
+	return relPath
 }
 
 // Fperms changes file permissions in ${D}.
@@ -1018,4 +1071,104 @@ func (h *Helpers) Fowners(args []string) error {
 
 	h.writeStdout(fmt.Sprintf(">>> fowners: %s\n", ownerGroup))
 	return nil
+}
+
+// ============================================================================
+// EAPI 8 Strip Control Functions
+// ============================================================================
+
+// Dostrip controls which files get stripped during installation.
+//
+// Usage: dostrip <path>...         - Include paths in stripping
+// Usage: dostrip -x <path>...      - Exclude paths from stripping
+//
+// Per PMS Section 11.3.3.17 (EAPI 8):
+//   - Without -x, adds paths to the list of files to strip
+//   - With -x, adds paths to the exclusion list (files that should NOT be stripped)
+//   - Paths are relative to ${ED} (e.g., /usr/bin, /usr/lib/debug)
+//
+// The strip lists are tracked in the Helpers struct and can be queried by
+// the installation system to determine which files should be stripped.
+func (h *Helpers) Dostrip(args []string) error {
+	if len(args) < 1 {
+		return &DieError{Message: "dostrip: no paths specified"}
+	}
+
+	exclude := false
+	paths := args
+
+	// Check for -x flag
+	if args[0] == "-x" {
+		exclude = true
+		paths = args[1:]
+		if len(paths) < 1 {
+			return &DieError{Message: "dostrip: no paths specified after -x"}
+		}
+	}
+
+	for _, p := range paths {
+		// Normalize path (ensure it starts with /)
+		if !strings.HasPrefix(p, "/") {
+			p = "/" + p
+		}
+
+		if exclude {
+			h.stripExclude = append(h.stripExclude, p)
+		} else {
+			h.stripInclude = append(h.stripInclude, p)
+		}
+	}
+
+	return nil
+}
+
+// GetStripInclude returns the list of paths to include in stripping.
+func (h *Helpers) GetStripInclude() []string {
+	return h.stripInclude
+}
+
+// GetStripExclude returns the list of paths to exclude from stripping.
+func (h *Helpers) GetStripExclude() []string {
+	return h.stripExclude
+}
+
+// ShouldStrip determines whether a file at the given path should be stripped.
+//
+// Logic:
+//   - If stripInclude is empty, default behavior applies (strip most binaries)
+//   - If stripInclude is set, only files under those paths are stripped
+//   - Files matching stripExclude are never stripped
+//
+// The path should be relative to ${ED} (e.g., /usr/bin/myapp).
+func (h *Helpers) ShouldStrip(path string) bool {
+	// Normalize path - use forward slashes for consistent comparison
+	// (GRPM targets Linux, but tests may run on Windows)
+	path = filepath.ToSlash(filepath.Clean(path))
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	// Check exclusion list first - exclusions always win
+	for _, exclude := range h.stripExclude {
+		exclude = filepath.ToSlash(filepath.Clean(exclude))
+		if strings.HasPrefix(path, exclude) {
+			return false
+		}
+	}
+
+	// If include list is empty, default is to strip (unless excluded above)
+	if len(h.stripInclude) == 0 {
+		return true
+	}
+
+	// Check if path is under any include path
+	for _, include := range h.stripInclude {
+		include = filepath.ToSlash(filepath.Clean(include))
+		if strings.HasPrefix(path, include) {
+			return true
+		}
+	}
+
+	// Not in include list
+	return false
 }

--- a/internal/ebuild/helpers_test.go
+++ b/internal/ebuild/helpers_test.go
@@ -537,6 +537,302 @@ func TestHelpers_InIuse_NoArgs(t *testing.T) {
 }
 
 // ============================================================================
+// UseEnable Tests (PMS Section 11.3.2.2)
+// ============================================================================
+
+func TestHelpers_UseEnable_EnabledFlag_OneArg(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// ssl is enabled
+	err := helpers.UseEnable([]string{"ssl"})
+	if err != nil {
+		t.Fatalf("UseEnable failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--enable-ssl" {
+		t.Errorf("expected '--enable-ssl', got: %s", output)
+	}
+}
+
+func TestHelpers_UseEnable_DisabledFlag_OneArg(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// doc is disabled
+	err := helpers.UseEnable([]string{"doc"})
+	if err != nil {
+		t.Fatalf("UseEnable failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--disable-doc" {
+		t.Errorf("expected '--disable-doc', got: %s", output)
+	}
+}
+
+func TestHelpers_UseEnable_EnabledFlag_TwoArgs(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// ssl is enabled, use custom option name
+	err := helpers.UseEnable([]string{"ssl", "openssl"})
+	if err != nil {
+		t.Fatalf("UseEnable failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--enable-openssl" {
+		t.Errorf("expected '--enable-openssl', got: %s", output)
+	}
+}
+
+func TestHelpers_UseEnable_DisabledFlag_TwoArgs(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// doc is disabled, use custom option name
+	err := helpers.UseEnable([]string{"doc", "documentation"})
+	if err != nil {
+		t.Fatalf("UseEnable failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--disable-documentation" {
+		t.Errorf("expected '--disable-documentation', got: %s", output)
+	}
+}
+
+func TestHelpers_UseEnable_EnabledFlag_ThreeArgs(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// ssl is enabled: use_enable ssl openssl yes
+	err := helpers.UseEnable([]string{"ssl", "openssl", "yes"})
+	if err != nil {
+		t.Fatalf("UseEnable failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--enable-openssl=yes" {
+		t.Errorf("expected '--enable-openssl=yes', got: %s", output)
+	}
+}
+
+func TestHelpers_UseEnable_DisabledFlag_ThreeArgs(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// doc is disabled: use_enable doc docs yes -> --disable-docs
+	err := helpers.UseEnable([]string{"doc", "docs", "yes"})
+	if err != nil {
+		t.Fatalf("UseEnable failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--disable-docs" {
+		t.Errorf("expected '--disable-docs', got: %s", output)
+	}
+}
+
+func TestHelpers_UseEnable_EnabledFlag_FourArgs(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// ssl is enabled: use_enable ssl openssl yes no -> --openssl=yes
+	err := helpers.UseEnable([]string{"ssl", "openssl", "yes", "no"})
+	if err != nil {
+		t.Fatalf("UseEnable failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--openssl=yes" {
+		t.Errorf("expected '--openssl=yes', got: %s", output)
+	}
+}
+
+func TestHelpers_UseEnable_DisabledFlag_FourArgs(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// doc is disabled: use_enable doc docs yes no -> --docs=no
+	err := helpers.UseEnable([]string{"doc", "docs", "yes", "no"})
+	if err != nil {
+		t.Fatalf("UseEnable failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--docs=no" {
+		t.Errorf("expected '--docs=no', got: %s", output)
+	}
+}
+
+func TestHelpers_UseEnable_NoArgs(t *testing.T) {
+	helpers, _, _ := createTestHelpers(t)
+
+	err := helpers.UseEnable([]string{})
+	if err == nil {
+		t.Error("expected error with no args")
+	}
+}
+
+func TestHelpers_UseEnable_UnknownFlag(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// unknownflag is not in IUSE, should be treated as disabled
+	err := helpers.UseEnable([]string{"unknownflag"})
+	if err != nil {
+		t.Fatalf("UseEnable failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--disable-unknownflag" {
+		t.Errorf("expected '--disable-unknownflag', got: %s", output)
+	}
+}
+
+// ============================================================================
+// UseWith Tests (PMS Section 11.3.2.3)
+// ============================================================================
+
+func TestHelpers_UseWith_EnabledFlag_OneArg(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// ssl is enabled
+	err := helpers.UseWith([]string{"ssl"})
+	if err != nil {
+		t.Fatalf("UseWith failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--with-ssl" {
+		t.Errorf("expected '--with-ssl', got: %s", output)
+	}
+}
+
+func TestHelpers_UseWith_DisabledFlag_OneArg(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// doc is disabled
+	err := helpers.UseWith([]string{"doc"})
+	if err != nil {
+		t.Fatalf("UseWith failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--without-doc" {
+		t.Errorf("expected '--without-doc', got: %s", output)
+	}
+}
+
+func TestHelpers_UseWith_EnabledFlag_TwoArgs(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// ssl is enabled, use custom option name
+	err := helpers.UseWith([]string{"ssl", "openssl"})
+	if err != nil {
+		t.Fatalf("UseWith failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--with-openssl" {
+		t.Errorf("expected '--with-openssl', got: %s", output)
+	}
+}
+
+func TestHelpers_UseWith_DisabledFlag_TwoArgs(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// doc is disabled, use custom option name
+	err := helpers.UseWith([]string{"doc", "documentation"})
+	if err != nil {
+		t.Fatalf("UseWith failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--without-documentation" {
+		t.Errorf("expected '--without-documentation', got: %s", output)
+	}
+}
+
+func TestHelpers_UseWith_EnabledFlag_ThreeArgs(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// ssl is enabled: use_with ssl openssl /usr
+	err := helpers.UseWith([]string{"ssl", "openssl", "/usr"})
+	if err != nil {
+		t.Fatalf("UseWith failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--with-openssl=/usr" {
+		t.Errorf("expected '--with-openssl=/usr', got: %s", output)
+	}
+}
+
+func TestHelpers_UseWith_DisabledFlag_ThreeArgs(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// doc is disabled: use_with doc docs /path -> --without-docs
+	err := helpers.UseWith([]string{"doc", "docs", "/path"})
+	if err != nil {
+		t.Fatalf("UseWith failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--without-docs" {
+		t.Errorf("expected '--without-docs', got: %s", output)
+	}
+}
+
+func TestHelpers_UseWith_EnabledFlag_FourArgs(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// ssl is enabled: use_with ssl openssl /usr/lib /none -> --openssl=/usr/lib
+	err := helpers.UseWith([]string{"ssl", "openssl", "/usr/lib", "/none"})
+	if err != nil {
+		t.Fatalf("UseWith failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--openssl=/usr/lib" {
+		t.Errorf("expected '--openssl=/usr/lib', got: %s", output)
+	}
+}
+
+func TestHelpers_UseWith_DisabledFlag_FourArgs(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// doc is disabled: use_with doc docs yes no -> --docs=no
+	err := helpers.UseWith([]string{"doc", "docs", "yes", "no"})
+	if err != nil {
+		t.Fatalf("UseWith failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--docs=no" {
+		t.Errorf("expected '--docs=no', got: %s", output)
+	}
+}
+
+func TestHelpers_UseWith_NoArgs(t *testing.T) {
+	helpers, _, _ := createTestHelpers(t)
+
+	err := helpers.UseWith([]string{})
+	if err == nil {
+		t.Error("expected error with no args")
+	}
+}
+
+func TestHelpers_UseWith_UnknownFlag(t *testing.T) {
+	helpers, stdout, _ := createTestHelpers(t)
+
+	// unknownflag is not in IUSE, should be treated as disabled
+	err := helpers.UseWith([]string{"unknownflag"})
+	if err != nil {
+		t.Fatalf("UseWith failed: %v", err)
+	}
+
+	output := stdout.String()
+	if output != "--without-unknownflag" {
+		t.Errorf("expected '--without-unknownflag', got: %s", output)
+	}
+}
+
+// ============================================================================
 // Toolchain Function Tests
 // ============================================================================
 
@@ -2905,5 +3201,582 @@ func TestHelpers_XargsReadWhitespaceDelimited(t *testing.T) {
 		if i >= len(args) || args[i] != exp {
 			t.Errorf("arg[%d] = %q, want %q", i, args[i], exp)
 		}
+	}
+}
+
+// ============================================================================
+// EAPI 8 Helper Tests: dosym -r, dostrip, einstalldocs
+// ============================================================================
+
+// TestCalculateRelativePath tests the relative path calculation for dosym -r
+func TestCalculateRelativePath(t *testing.T) {
+	tests := []struct {
+		name       string
+		linkPath   string
+		targetPath string
+		want       string
+	}{
+		{
+			name:       "same directory - library version symlink",
+			linkPath:   "/usr/lib/libfoo.so",
+			targetPath: "/usr/lib/libfoo.so.1",
+			want:       "libfoo.so.1",
+		},
+		{
+			name:       "same directory - python symlink",
+			linkPath:   "/usr/bin/python",
+			targetPath: "/usr/bin/python3.11",
+			want:       "python3.11",
+		},
+		{
+			name:       "cross directory - lib to lib64",
+			linkPath:   "/usr/lib/libfoo.so",
+			targetPath: "/usr/lib64/libfoo.so.1",
+			want:       "../lib64/libfoo.so.1",
+		},
+		{
+			name:       "multiple levels up",
+			linkPath:   "/usr/lib/foo/bar/libfoo.so",
+			targetPath: "/usr/lib64/libfoo.so.1",
+			want:       "../../../lib64/libfoo.so.1", // Fixed: 3 levels up from /usr/lib/foo/bar
+		},
+		{
+			name:       "deep target path",
+			linkPath:   "/usr/bin/app",
+			targetPath: "/opt/app/v1.0/bin/app",
+			want:       "../../opt/app/v1.0/bin/app",
+		},
+		{
+			name:       "same file name different dir",
+			linkPath:   "/etc/alternatives/java",
+			targetPath: "/usr/lib/jvm/java-11/bin/java",
+			want:       "../../usr/lib/jvm/java-11/bin/java", // Fixed: 2 levels up from /etc/alternatives
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateRelativePath(tt.linkPath, tt.targetPath)
+			// On Windows, paths may use backslash - normalize for comparison
+			got = filepath.ToSlash(got)
+			if got != tt.want {
+				t.Errorf("calculateRelativePath(%q, %q) = %q, want %q",
+					tt.linkPath, tt.targetPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHelpers_Dosym_Basic(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping symlink test on Windows (requires admin privileges)")
+	}
+
+	helpers, _ := createInstallTestHelpers(t)
+
+	err := helpers.Dosym([]string{"/usr/lib/libfoo.so.1", "/usr/lib/libfoo.so"})
+	if err != nil {
+		t.Fatalf("Dosym failed: %v", err)
+	}
+
+	// Check symlink was created
+	linkPath := filepath.Join(helpers.env.D, "usr", "lib", "libfoo.so")
+	info, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("failed to stat symlink: %v", err)
+	}
+
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Error("expected symlink to be created")
+	}
+
+	// Check target
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("failed to readlink: %v", err)
+	}
+	if target != "/usr/lib/libfoo.so.1" {
+		t.Errorf("symlink target = %q, want /usr/lib/libfoo.so.1", target)
+	}
+}
+
+func TestHelpers_Dosym_Relative(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping symlink test on Windows (requires admin privileges)")
+	}
+
+	helpers, _ := createInstallTestHelpers(t)
+
+	// Use -r flag for automatic relative path calculation
+	err := helpers.Dosym([]string{"-r", "/usr/lib/libfoo.so.1", "/usr/lib/libfoo.so"})
+	if err != nil {
+		t.Fatalf("Dosym -r failed: %v", err)
+	}
+
+	// Check symlink was created
+	linkPath := filepath.Join(helpers.env.D, "usr", "lib", "libfoo.so")
+	info, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("failed to stat symlink: %v", err)
+	}
+
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Error("expected symlink to be created")
+	}
+
+	// Check that target is relative (not absolute)
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("failed to readlink: %v", err)
+	}
+	// Should be "libfoo.so.1", not "/usr/lib/libfoo.so.1"
+	if target != "libfoo.so.1" {
+		t.Errorf("relative symlink target = %q, want libfoo.so.1", target)
+	}
+}
+
+func TestHelpers_Dosym_RelativeCrossDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping symlink test on Windows (requires admin privileges)")
+	}
+
+	helpers, _ := createInstallTestHelpers(t)
+
+	// Cross-directory relative symlink
+	err := helpers.Dosym([]string{"-r", "/usr/lib64/libfoo.so.1", "/usr/lib/libfoo.so"})
+	if err != nil {
+		t.Fatalf("Dosym -r cross-dir failed: %v", err)
+	}
+
+	linkPath := filepath.Join(helpers.env.D, "usr", "lib", "libfoo.so")
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("failed to readlink: %v", err)
+	}
+
+	// Should be relative path like "../lib64/libfoo.so.1"
+	expected := "../lib64/libfoo.so.1"
+	target = filepath.ToSlash(target) // Normalize for Windows
+	if target != expected {
+		t.Errorf("cross-dir symlink target = %q, want %q", target, expected)
+	}
+}
+
+func TestHelpers_DosymRelative_NoArgs(t *testing.T) {
+	helpers, _ := createInstallTestHelpers(t)
+
+	err := helpers.Dosym([]string{})
+	if err == nil {
+		t.Error("expected error with no args")
+	}
+}
+
+func TestHelpers_DosymRelative_OnlyTarget(t *testing.T) {
+	helpers, _ := createInstallTestHelpers(t)
+
+	err := helpers.Dosym([]string{"/target"})
+	if err == nil {
+		t.Error("expected error with only target")
+	}
+}
+
+func TestHelpers_DosymRelative_OnlyFlag(t *testing.T) {
+	helpers, _ := createInstallTestHelpers(t)
+
+	// -r with no other args
+	err := helpers.Dosym([]string{"-r"})
+	if err == nil {
+		t.Error("expected error with -r flag only")
+	}
+
+	// -r with only target
+	err = helpers.Dosym([]string{"-r", "/target"})
+	if err == nil {
+		t.Error("expected error with -r and only target")
+	}
+}
+
+// ============================================================================
+// Dostrip Tests
+// ============================================================================
+
+func TestHelpers_Dostrip_Include(t *testing.T) {
+	helpers, _, _ := createTestHelpers(t)
+
+	err := helpers.Dostrip([]string{"/usr/bin", "/usr/lib"})
+	if err != nil {
+		t.Fatalf("Dostrip failed: %v", err)
+	}
+
+	include := helpers.GetStripInclude()
+	if len(include) != 2 {
+		t.Errorf("expected 2 include paths, got %d", len(include))
+	}
+
+	expected := []string{"/usr/bin", "/usr/lib"}
+	for i, exp := range expected {
+		if i >= len(include) || include[i] != exp {
+			t.Errorf("include[%d] = %q, want %q", i, include[i], exp)
+		}
+	}
+}
+
+func TestHelpers_Dostrip_Exclude(t *testing.T) {
+	helpers, _, _ := createTestHelpers(t)
+
+	err := helpers.Dostrip([]string{"-x", "/usr/lib/debug"})
+	if err != nil {
+		t.Fatalf("Dostrip -x failed: %v", err)
+	}
+
+	exclude := helpers.GetStripExclude()
+	if len(exclude) != 1 {
+		t.Errorf("expected 1 exclude path, got %d", len(exclude))
+	}
+	if len(exclude) > 0 && exclude[0] != "/usr/lib/debug" {
+		t.Errorf("exclude[0] = %q, want /usr/lib/debug", exclude[0])
+	}
+}
+
+func TestHelpers_Dostrip_Mixed(t *testing.T) {
+	helpers, _, _ := createTestHelpers(t)
+
+	// First add includes
+	err := helpers.Dostrip([]string{"/usr/bin", "/usr/lib"})
+	if err != nil {
+		t.Fatalf("Dostrip include failed: %v", err)
+	}
+
+	// Then add excludes
+	err = helpers.Dostrip([]string{"-x", "/usr/lib/debug", "/usr/lib/modules"})
+	if err != nil {
+		t.Fatalf("Dostrip exclude failed: %v", err)
+	}
+
+	include := helpers.GetStripInclude()
+	exclude := helpers.GetStripExclude()
+
+	if len(include) != 2 {
+		t.Errorf("expected 2 include paths, got %d", len(include))
+	}
+	if len(exclude) != 2 {
+		t.Errorf("expected 2 exclude paths, got %d", len(exclude))
+	}
+}
+
+func TestHelpers_Dostrip_NoArgs(t *testing.T) {
+	helpers, _, _ := createTestHelpers(t)
+
+	err := helpers.Dostrip([]string{})
+	if err == nil {
+		t.Error("expected error with no args")
+	}
+}
+
+func TestHelpers_Dostrip_ExcludeNoArgs(t *testing.T) {
+	helpers, _, _ := createTestHelpers(t)
+
+	err := helpers.Dostrip([]string{"-x"})
+	if err == nil {
+		t.Error("expected error with -x but no paths")
+	}
+}
+
+func TestHelpers_Dostrip_NormalizePath(t *testing.T) {
+	helpers, _, _ := createTestHelpers(t)
+
+	// Path without leading slash should be normalized
+	err := helpers.Dostrip([]string{"usr/bin"})
+	if err != nil {
+		t.Fatalf("Dostrip failed: %v", err)
+	}
+
+	include := helpers.GetStripInclude()
+	if len(include) != 1 {
+		t.Fatalf("expected 1 include path, got %d", len(include))
+	}
+	if include[0] != "/usr/bin" {
+		t.Errorf("include[0] = %q, want /usr/bin (normalized)", include[0])
+	}
+}
+
+// ============================================================================
+// ShouldStrip Tests
+// ============================================================================
+
+func TestHelpers_ShouldStrip_Default(t *testing.T) {
+	helpers, _, _ := createTestHelpers(t)
+
+	// By default (no include/exclude set), everything should be stripped
+	if !helpers.ShouldStrip("/usr/bin/foo") {
+		t.Error("expected /usr/bin/foo to be stripped by default")
+	}
+	if !helpers.ShouldStrip("/usr/lib/libfoo.so") {
+		t.Error("expected /usr/lib/libfoo.so to be stripped by default")
+	}
+}
+
+func TestHelpers_ShouldStrip_WithExclude(t *testing.T) {
+	helpers, _, _ := createTestHelpers(t)
+
+	// Exclude debug directory
+	_ = helpers.Dostrip([]string{"-x", "/usr/lib/debug"})
+
+	// Files in excluded path should not be stripped
+	if helpers.ShouldStrip("/usr/lib/debug/foo.debug") {
+		t.Error("expected /usr/lib/debug/foo.debug to NOT be stripped")
+	}
+
+	// Files outside excluded path should be stripped
+	if !helpers.ShouldStrip("/usr/bin/foo") {
+		t.Error("expected /usr/bin/foo to be stripped")
+	}
+}
+
+func TestHelpers_ShouldStrip_WithInclude(t *testing.T) {
+	helpers, _, _ := createTestHelpers(t)
+
+	// Only include /usr/bin
+	_ = helpers.Dostrip([]string{"/usr/bin"})
+
+	// Files in included path should be stripped
+	if !helpers.ShouldStrip("/usr/bin/foo") {
+		t.Error("expected /usr/bin/foo to be stripped")
+	}
+
+	// Files outside included path should NOT be stripped
+	if helpers.ShouldStrip("/usr/lib/libfoo.so") {
+		t.Error("expected /usr/lib/libfoo.so to NOT be stripped")
+	}
+}
+
+func TestHelpers_ShouldStrip_ExcludeWins(t *testing.T) {
+	helpers, _, _ := createTestHelpers(t)
+
+	// Include entire /usr/lib
+	_ = helpers.Dostrip([]string{"/usr/lib"})
+	// But exclude debug subdirectory
+	_ = helpers.Dostrip([]string{"-x", "/usr/lib/debug"})
+
+	// Should strip files in /usr/lib
+	if !helpers.ShouldStrip("/usr/lib/libfoo.so") {
+		t.Error("expected /usr/lib/libfoo.so to be stripped")
+	}
+
+	// Should NOT strip files in excluded subpath
+	if helpers.ShouldStrip("/usr/lib/debug/foo.debug") {
+		t.Error("expected /usr/lib/debug/foo.debug to NOT be stripped (exclude wins)")
+	}
+}
+
+// ============================================================================
+// Einstalldocs Tests
+// ============================================================================
+
+func TestHelpers_Einstalldocs_StandardFiles(t *testing.T) {
+	helpers, tmpDir := createInstallTestHelpers(t)
+
+	// Set source directory
+	sourceDir := filepath.Join(tmpDir, "source")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatalf("failed to create source dir: %v", err)
+	}
+	helpers.env.S = sourceDir
+
+	// Create standard documentation files
+	docsToCreate := []string{"README", "LICENSE", "CHANGELOG", "AUTHORS"}
+	for _, doc := range docsToCreate {
+		docPath := filepath.Join(sourceDir, doc)
+		if err := os.WriteFile(docPath, []byte("test content for "+doc), 0644); err != nil {
+			t.Fatalf("failed to create %s: %v", doc, err)
+		}
+	}
+
+	err := helpers.Einstalldocs([]string{})
+	if err != nil {
+		t.Fatalf("Einstalldocs failed: %v", err)
+	}
+
+	// Check that files were installed
+	docDir := filepath.Join(helpers.env.D, "usr", "share", "doc", helpers.env.PF)
+	for _, doc := range docsToCreate {
+		docPath := filepath.Join(docDir, doc)
+		if _, err := os.Stat(docPath); os.IsNotExist(err) {
+			t.Errorf("expected %s to be installed at %s", doc, docPath)
+		}
+	}
+}
+
+func TestHelpers_Einstalldocs_WithDOCS(t *testing.T) {
+	helpers, tmpDir := createInstallTestHelpers(t)
+
+	// Set source directory
+	sourceDir := filepath.Join(tmpDir, "source")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatalf("failed to create source dir: %v", err)
+	}
+	helpers.env.S = sourceDir
+
+	// Create custom doc file
+	customDoc := filepath.Join(sourceDir, "CUSTOM.md")
+	if err := os.WriteFile(customDoc, []byte("custom doc"), 0644); err != nil {
+		t.Fatalf("failed to create custom doc: %v", err)
+	}
+
+	// Set DOCS variable
+	helpers.env.SetVar("DOCS", "CUSTOM.md")
+
+	err := helpers.Einstalldocs([]string{})
+	if err != nil {
+		t.Fatalf("Einstalldocs failed: %v", err)
+	}
+
+	// Check that CUSTOM.md was installed
+	docDir := filepath.Join(helpers.env.D, "usr", "share", "doc", helpers.env.PF)
+	customPath := filepath.Join(docDir, "CUSTOM.md")
+	if _, err := os.Stat(customPath); os.IsNotExist(err) {
+		t.Errorf("expected CUSTOM.md to be installed at %s", customPath)
+	}
+}
+
+func TestHelpers_Einstalldocs_NoSourceDir(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	helpers := NewHelpers(nil, &stdout, &stderr)
+
+	err := helpers.Einstalldocs([]string{})
+	if err == nil {
+		t.Error("expected error when S is not set")
+	}
+}
+
+func TestHelpers_Einstalldocs_EmptySourceDir(t *testing.T) {
+	helpers, tmpDir := createInstallTestHelpers(t)
+
+	// Set source directory (empty)
+	sourceDir := filepath.Join(tmpDir, "source")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatalf("failed to create source dir: %v", err)
+	}
+	helpers.env.S = sourceDir
+
+	// Should succeed even with no files to install
+	err := helpers.Einstalldocs([]string{})
+	if err != nil {
+		t.Errorf("Einstalldocs failed on empty dir: %v", err)
+	}
+}
+
+func TestHelpers_Einstalldocs_PatternMatching(t *testing.T) {
+	helpers, tmpDir := createInstallTestHelpers(t)
+
+	// Set source directory
+	sourceDir := filepath.Join(tmpDir, "source")
+	if err := os.MkdirAll(sourceDir, 0755); err != nil {
+		t.Fatalf("failed to create source dir: %v", err)
+	}
+	helpers.env.S = sourceDir
+
+	// Create files matching various patterns
+	files := []string{
+		"README.md",
+		"README.rst",
+		"LICENSE-MIT",
+		"ChangeLog.txt",
+		"NEWS",
+	}
+	for _, f := range files {
+		fPath := filepath.Join(sourceDir, f)
+		if err := os.WriteFile(fPath, []byte("content"), 0644); err != nil {
+			t.Fatalf("failed to create %s: %v", f, err)
+		}
+	}
+
+	err := helpers.Einstalldocs([]string{})
+	if err != nil {
+		t.Fatalf("Einstalldocs failed: %v", err)
+	}
+
+	// Check files were installed
+	docDir := filepath.Join(helpers.env.D, "usr", "share", "doc", helpers.env.PF)
+	for _, f := range files {
+		fPath := filepath.Join(docDir, f)
+		if _, err := os.Stat(fPath); os.IsNotExist(err) {
+			t.Errorf("expected %s to be installed at %s", f, fPath)
+		}
+	}
+}
+
+// ============================================================================
+// Environment GetVar/SetVar Tests
+// ============================================================================
+
+func TestEnvironment_GetVar_BuiltIn(t *testing.T) {
+	testPkg := &pkg.Package{
+		Name:    "sys-libs/zlib",
+		Version: "1.2.13",
+	}
+
+	env, err := NewEnvironment(testPkg, "/var/tmp/portage", "/var/db/repos/gentoo", "/var/cache/distfiles")
+	if err != nil {
+		t.Fatalf("failed to create environment: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"PN", "zlib"},
+		{"PV", "1.2.13"},
+		{"CATEGORY", "sys-libs"},
+		{"EAPI", "8"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := env.GetVar(tt.name)
+			if got != tt.want {
+				t.Errorf("GetVar(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnvironment_GetVar_Extra(t *testing.T) {
+	testPkg := &pkg.Package{
+		Name:    "sys-libs/zlib",
+		Version: "1.2.13",
+	}
+
+	env, err := NewEnvironment(testPkg, "/var/tmp/portage", "/var/db/repos/gentoo", "/var/cache/distfiles")
+	if err != nil {
+		t.Fatalf("failed to create environment: %v", err)
+	}
+
+	// Set extra variable
+	env.SetVar("DOCS", "README.md CHANGELOG")
+	env.SetVar("HTML_DOCS", "doc/html")
+
+	// Check retrieval
+	if got := env.GetVar("DOCS"); got != "README.md CHANGELOG" {
+		t.Errorf("GetVar(DOCS) = %q, want %q", got, "README.md CHANGELOG")
+	}
+	if got := env.GetVar("HTML_DOCS"); got != "doc/html" {
+		t.Errorf("GetVar(HTML_DOCS) = %q, want %q", got, "doc/html")
+	}
+}
+
+func TestEnvironment_GetVar_NotFound(t *testing.T) {
+	testPkg := &pkg.Package{
+		Name:    "sys-libs/zlib",
+		Version: "1.2.13",
+	}
+
+	env, err := NewEnvironment(testPkg, "/var/tmp/portage", "/var/db/repos/gentoo", "/var/cache/distfiles")
+	if err != nil {
+		t.Fatalf("failed to create environment: %v", err)
+	}
+
+	if got := env.GetVar("NONEXISTENT"); got != "" {
+		t.Errorf("GetVar(NONEXISTENT) = %q, want empty string", got)
 	}
 }

--- a/internal/ebuild/helpers_use.go
+++ b/internal/ebuild/helpers_use.go
@@ -193,3 +193,113 @@ func (h *Helpers) isInIuse(flag string) bool {
 	// TODO: Add IUSE field to Environment struct
 	return false
 }
+
+// ============================================================================
+// EAPI 8 USE Flag Configure Helpers (PMS Section 11.3.2)
+// ============================================================================
+
+// UseEnable outputs --enable-${opt} or --disable-${opt} for ./configure.
+//
+// Per PMS Section 11.3.2.2, this function is used to generate autoconf-style
+// configure options based on USE flag state.
+//
+// Usage:
+//
+//	use_enable <flag>                        -> --enable-flag or --disable-flag
+//	use_enable <flag> <option>               -> --enable-option or --disable-option
+//	use_enable <flag> <opt> <val_if_true> <val_if_false> -> --opt=val_if_true or --opt=val_if_false
+//
+// Examples:
+//
+//	use_enable ssl           -> --enable-ssl (if ssl enabled) or --disable-ssl
+//	use_enable ssl openssl   -> --enable-openssl (if ssl enabled) or --disable-openssl
+//	use_enable ssl openssl yes no -> --openssl=yes (if enabled) or --openssl=no
+func (h *Helpers) UseEnable(args []string) error {
+	if len(args) < 1 {
+		return exitFalse()
+	}
+
+	result := h.useConfigureHelper(args, "enable", "disable")
+	h.writeStdout(result)
+	return nil
+}
+
+// UseWith outputs --with-${opt} or --without-${opt} for ./configure.
+//
+// Per PMS Section 11.3.2.3, this function is used to generate autoconf-style
+// configure options for optional dependencies based on USE flag state.
+//
+// Usage:
+//
+//	use_with <flag>                        -> --with-flag or --without-flag
+//	use_with <flag> <option>               -> --with-option or --without-option
+//	use_with <flag> <opt> <val_if_true> <val_if_false> -> --opt=val_if_true or --opt=val_if_false
+//
+// Examples:
+//
+//	use_with ssl           -> --with-ssl (if ssl enabled) or --without-ssl
+//	use_with ssl openssl   -> --with-openssl (if ssl enabled) or --without-openssl
+//	use_with ssl openssl yes no -> --openssl=yes (if enabled) or --openssl=no
+func (h *Helpers) UseWith(args []string) error {
+	if len(args) < 1 {
+		return exitFalse()
+	}
+
+	result := h.useConfigureHelper(args, "with", "without")
+	h.writeStdout(result)
+	return nil
+}
+
+// useConfigureHelper is the common implementation for use_enable and use_with.
+//
+// Parameters:
+//   - args: Command arguments [flag, option?, val_if_true?, val_if_false?]
+//   - enablePrefix: Prefix for enabled state (e.g., "enable" or "with")
+//   - disablePrefix: Prefix for disabled state (e.g., "disable" or "without")
+//
+// Return format depends on argument count:
+//   - 1 arg:  --{prefix}-{flag}
+//   - 2 args: --{prefix}-{option}
+//   - 4 args: --{option}={value}
+func (h *Helpers) useConfigureHelper(args []string, enablePrefix, disablePrefix string) string {
+	flag := args[0]
+	enabled := h.isUseEnabled(flag)
+
+	switch len(args) {
+	case 1:
+		// use_enable flag -> --enable-flag or --disable-flag
+		if enabled {
+			return "--" + enablePrefix + "-" + flag
+		}
+		return "--" + disablePrefix + "-" + flag
+
+	case 2:
+		// use_enable flag option -> --enable-option or --disable-option
+		option := args[1]
+		if enabled {
+			return "--" + enablePrefix + "-" + option
+		}
+		return "--" + disablePrefix + "-" + option
+
+	case 3:
+		// Per PMS, 3 arguments is valid: use_enable flag opt value
+		// This outputs --enable-opt=value or --disable-opt
+		option := args[1]
+		value := args[2]
+		if enabled {
+			return "--" + enablePrefix + "-" + option + "=" + value
+		}
+		return "--" + disablePrefix + "-" + option
+
+	default:
+		// 4+ args: use_enable flag opt val_if_true val_if_false
+		// Outputs --opt=val_if_true or --opt=val_if_false
+		option := args[1]
+		valTrue := args[2]
+		valFalse := args[3]
+		if enabled {
+			return "--" + option + "=" + valTrue
+		}
+		return "--" + option + "=" + valFalse
+	}
+}

--- a/internal/ebuild/interpreter.go
+++ b/internal/ebuild/interpreter.go
@@ -164,11 +164,13 @@ func (i *Interpreter) buildCommandMap() map[string]helperFunc {
 		"eend":   i.helpers.Eend,
 
 		// USE flag functions
-		"has":     i.helpers.Has,
-		"use":     i.helpers.Use,
-		"usev":    i.helpers.Usev,
-		"usex":    i.helpers.Usex,
-		"in_iuse": i.helpers.InIuse,
+		"has":        i.helpers.Has,
+		"use":        i.helpers.Use,
+		"usev":       i.helpers.Usev,
+		"usex":       i.helpers.Usex,
+		"in_iuse":    i.helpers.InIuse,
+		"use_enable": i.helpers.UseEnable,
+		"use_with":   i.helpers.UseWith,
 
 		// Toolchain functions
 		"tc-getCC":  i.helpers.TcGetCC,
@@ -236,13 +238,15 @@ func (i *Interpreter) buildCommandMap() map[string]helperFunc {
 		"ver_rs":  i.helpers.VerRs,
 
 		// Additional installation helpers
-		"dosym":   i.helpers.Dosym,
-		"fperms":  i.helpers.Fperms,
-		"fowners": i.helpers.Fowners,
-		"doconfd": i.helpers.Doconfd,
-		"doinitd": i.helpers.Doinitd,
-		"doenvd":  i.helpers.Doenvd,
-		"inherit": i.helpers.Inherit,
+		"dosym":        i.helpers.Dosym,
+		"fperms":       i.helpers.Fperms,
+		"fowners":      i.helpers.Fowners,
+		"doconfd":      i.helpers.Doconfd,
+		"doinitd":      i.helpers.Doinitd,
+		"doenvd":       i.helpers.Doenvd,
+		"dostrip":      i.helpers.Dostrip,
+		"einstalldocs": i.helpers.Einstalldocs,
+		"inherit":      i.helpers.Inherit,
 
 		// File system utilities (common in ebuilds)
 		"sed":        i.helpers.Sed,
@@ -317,7 +321,7 @@ func (i *Interpreter) buildCommandMap() map[string]helperFunc {
 //
 // Commands handled:
 //   - die, einfo, ewarn, eerror, elog, ebegin, eend, eqawarn (messaging)
-//   - has, use, usev, usex, in_iuse (USE flags)
+//   - has, use, usev, usex, in_iuse, use_enable, use_with (USE flags)
 //   - tc-getCC, tc-getCXX, tc-getLD, tc-arch (toolchain-funcs)
 //   - tc-is-gcc, tc-is-clang, tc-export, tc-getAR, etc. (toolchain-funcs)
 //   - insinto, exeinto, docinto (directory setting)

--- a/internal/ebuild/interpreter_test.go
+++ b/internal/ebuild/interpreter_test.go
@@ -319,6 +319,158 @@ func TestInterpreter_Run_Has_NotFound(t *testing.T) {
 	}
 }
 
+func TestInterpreter_Run_UseEnable(t *testing.T) {
+	env := createTestEnvironment(t)
+	var stdout, stderr bytes.Buffer
+
+	interp := NewInterpreter(env, &stdout, &stderr)
+
+	// use_enable with enabled flag (ssl)
+	err := interp.Run(context.Background(), `use_enable ssl`)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "--enable-ssl") {
+		t.Errorf("expected '--enable-ssl', got: %s", output)
+	}
+}
+
+func TestInterpreter_Run_UseEnable_Disabled(t *testing.T) {
+	env := createTestEnvironment(t)
+	var stdout, stderr bytes.Buffer
+
+	interp := NewInterpreter(env, &stdout, &stderr)
+
+	// use_enable with disabled flag (doc)
+	err := interp.Run(context.Background(), `use_enable doc`)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "--disable-doc") {
+		t.Errorf("expected '--disable-doc', got: %s", output)
+	}
+}
+
+func TestInterpreter_Run_UseEnable_CustomOption(t *testing.T) {
+	env := createTestEnvironment(t)
+	var stdout, stderr bytes.Buffer
+
+	interp := NewInterpreter(env, &stdout, &stderr)
+
+	// use_enable with custom option name
+	err := interp.Run(context.Background(), `use_enable ssl openssl`)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "--enable-openssl") {
+		t.Errorf("expected '--enable-openssl', got: %s", output)
+	}
+}
+
+func TestInterpreter_Run_UseEnable_FourArgs(t *testing.T) {
+	env := createTestEnvironment(t)
+	var stdout, stderr bytes.Buffer
+
+	interp := NewInterpreter(env, &stdout, &stderr)
+
+	// use_enable with 4 args: flag opt val_true val_false
+	err := interp.Run(context.Background(), `use_enable ssl openssl yes no`)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "--openssl=yes") {
+		t.Errorf("expected '--openssl=yes', got: %s", output)
+	}
+}
+
+func TestInterpreter_Run_UseWith(t *testing.T) {
+	env := createTestEnvironment(t)
+	var stdout, stderr bytes.Buffer
+
+	interp := NewInterpreter(env, &stdout, &stderr)
+
+	// use_with with enabled flag (ssl)
+	err := interp.Run(context.Background(), `use_with ssl`)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "--with-ssl") {
+		t.Errorf("expected '--with-ssl', got: %s", output)
+	}
+}
+
+func TestInterpreter_Run_UseWith_Disabled(t *testing.T) {
+	env := createTestEnvironment(t)
+	var stdout, stderr bytes.Buffer
+
+	interp := NewInterpreter(env, &stdout, &stderr)
+
+	// use_with with disabled flag (doc)
+	err := interp.Run(context.Background(), `use_with doc`)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "--without-doc") {
+		t.Errorf("expected '--without-doc', got: %s", output)
+	}
+}
+
+func TestInterpreter_Run_UseWith_FourArgs(t *testing.T) {
+	env := createTestEnvironment(t)
+	var stdout, stderr bytes.Buffer
+
+	interp := NewInterpreter(env, &stdout, &stderr)
+
+	// use_with with 4 args: flag opt val_true val_false
+	err := interp.Run(context.Background(), `use_with doc docs /path /none`)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "--docs=/none") {
+		t.Errorf("expected '--docs=/none', got: %s", output)
+	}
+}
+
+func TestInterpreter_Run_UseEnable_InScript(t *testing.T) {
+	env := createTestEnvironment(t)
+	var stdout, stderr bytes.Buffer
+
+	interp := NewInterpreter(env, &stdout, &stderr)
+
+	// Typical ebuild usage: building configure args with use_enable
+	err := interp.Run(context.Background(), `
+		args=""
+		args="$args $(use_enable ssl)"
+		args="$args $(use_enable doc)"
+		echo "CONFIGURE_ARGS:$args"
+	`)
+	if err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "--enable-ssl") {
+		t.Errorf("expected '--enable-ssl' in output, got: %s", output)
+	}
+	if !strings.Contains(output, "--disable-doc") {
+		t.Errorf("expected '--disable-doc' in output, got: %s", output)
+	}
+}
+
 func TestInterpreter_Run_TcGetCC(t *testing.T) {
 	env := createTestEnvironment(t)
 	var stdout, stderr bytes.Buffer

--- a/internal/fetch/srcuri.go
+++ b/internal/fetch/srcuri.go
@@ -1,0 +1,116 @@
+// Package fetch implements distfile (source tarball) fetching for GRPM.
+//
+// This file provides integration between SRC_URI parsing and distfile fetching.
+package fetch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grpmsoft/grpm/internal/repo"
+)
+
+// SrcURIFetcher provides high-level SRC_URI-based fetching.
+//
+// It combines SRC_URI parsing with manifest-based checksum verification
+// and the actual download process.
+type SrcURIFetcher struct {
+	downloader Fetcher
+	config     Config
+}
+
+// NewSrcURIFetcher creates a new SRC_URI fetcher.
+//
+// The fetcher uses the provided configuration for mirrors and download settings.
+func NewSrcURIFetcher(config Config) *SrcURIFetcher {
+	return &SrcURIFetcher{
+		downloader: NewHTTPDownloader(config),
+		config:     config,
+	}
+}
+
+// FetchSrcURI parses SRC_URI and fetches the required distfiles.
+//
+// Parameters:
+//   - ctx: context for cancellation
+//   - srcURI: the SRC_URI content from the ebuild
+//   - manifest: parsed Manifest with checksums
+//   - activeFlags: enabled USE flags for conditional filtering
+//   - vars: package variables for expansion (P, PV, PN, etc.)
+//   - destDir: destination directory for downloads
+//
+// The function:
+//  1. Parses SRC_URI to extract download entries
+//  2. Filters entries based on active USE flags
+//  3. Looks up checksums from the Manifest
+//  4. Downloads and verifies each file
+func (f *SrcURIFetcher) FetchSrcURI(
+	ctx context.Context,
+	srcURI string,
+	manifest *Manifest,
+	activeFlags map[string]bool,
+	vars map[string]string,
+	destDir string,
+) error {
+	// Parse SRC_URI
+	entries, err := repo.ParseSrcURI(srcURI, activeFlags, vars)
+	if err != nil {
+		return fmt.Errorf("parsing SRC_URI: %w", err)
+	}
+
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// Convert entries to distfiles
+	distfiles, err := f.entriesToDistfiles(entries, manifest)
+	if err != nil {
+		return err
+	}
+
+	// Fetch all distfiles
+	return f.downloader.Fetch(ctx, distfiles, destDir)
+}
+
+// entriesToDistfiles converts SrcURIEntry to Distfile with checksums from Manifest.
+func (f *SrcURIFetcher) entriesToDistfiles(entries []repo.SrcURIEntry, manifest *Manifest) ([]Distfile, error) {
+	distfiles := make([]Distfile, 0, len(entries))
+	seen := make(map[string]bool)
+
+	for _, entry := range entries {
+		// Skip duplicates (same filename)
+		if seen[entry.Filename] {
+			continue
+		}
+		seen[entry.Filename] = true
+
+		// Look up checksum info from manifest
+		manifestEntry, ok := manifest.GetEntry(entry.Filename)
+		if !ok {
+			return nil, fmt.Errorf("distfile %s not found in Manifest", entry.Filename)
+		}
+
+		// Create distfile with checksum and URI
+		distfile := NewDistfile(entry.Filename, manifestEntry.Size, manifestEntry.Checksums)
+
+		// Add the explicit URI if present
+		if entry.URL != "" {
+			distfile = distfile.WithURIs([]string{entry.URL})
+		}
+
+		distfiles = append(distfiles, distfile)
+	}
+
+	return distfiles, nil
+}
+
+// ParseAndListDistfiles parses SRC_URI and returns the list of required distfiles.
+//
+// This is useful for dry-run operations or showing what would be downloaded.
+func ParseAndListDistfiles(
+	srcURI string,
+	activeFlags map[string]bool,
+	vars map[string]string,
+) ([]repo.SrcURIEntry, error) {
+	return repo.ParseSrcURI(srcURI, activeFlags, vars)
+}

--- a/internal/fetch/srcuri_test.go
+++ b/internal/fetch/srcuri_test.go
@@ -1,0 +1,301 @@
+package fetch
+
+import (
+	"testing"
+
+	"github.com/grpmsoft/grpm/internal/repo"
+)
+
+func TestParseAndListDistfiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		srcURI    string
+		flags     map[string]bool
+		vars      map[string]string
+		wantLen   int
+		wantFiles []string
+		wantErr   bool
+	}{
+		{
+			name:      "simple URL",
+			srcURI:    "https://example.com/file.tar.gz",
+			wantLen:   1,
+			wantFiles: []string{"file.tar.gz"},
+		},
+		{
+			name:      "arrow syntax",
+			srcURI:    "https://example.com/src.tar.gz -> custom.tar.gz",
+			wantLen:   1,
+			wantFiles: []string{"custom.tar.gz"},
+		},
+		{
+			name:      "conditional enabled",
+			srcURI:    "doc? ( https://example.com/doc.pdf )",
+			flags:     map[string]bool{"doc": true},
+			wantLen:   1,
+			wantFiles: []string{"doc.pdf"},
+		},
+		{
+			name:    "conditional disabled",
+			srcURI:  "doc? ( https://example.com/doc.pdf )",
+			flags:   map[string]bool{"doc": false},
+			wantLen: 0,
+		},
+		{
+			name:      "variable expansion",
+			srcURI:    "https://example.com/src.tar.gz -> ${P}.tar.gz",
+			vars:      map[string]string{"P": "hello-1.0"},
+			wantLen:   1,
+			wantFiles: []string{"hello-1.0.tar.gz"},
+		},
+		{
+			name:      "mixed content",
+			srcURI:    "https://example.com/main.tar.gz doc? ( https://example.com/doc.pdf )",
+			flags:     map[string]bool{"doc": true},
+			wantLen:   2,
+			wantFiles: []string{"main.tar.gz", "doc.pdf"},
+		},
+		{
+			name:    "empty input",
+			srcURI:  "",
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			entries, err := ParseAndListDistfiles(tt.srcURI, tt.flags, tt.vars)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseAndListDistfiles() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if len(entries) != tt.wantLen {
+				t.Fatalf("got %d entries, want %d", len(entries), tt.wantLen)
+			}
+
+			if tt.wantFiles != nil {
+				for i, wantFile := range tt.wantFiles {
+					if i >= len(entries) {
+						t.Errorf("missing expected file: %s", wantFile)
+						continue
+					}
+					if entries[i].Filename != wantFile {
+						t.Errorf("entry[%d].Filename = %q, want %q", i, entries[i].Filename, wantFile)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSrcURIFetcher_entriesToDistfiles(t *testing.T) {
+	t.Parallel()
+
+	// Create a mock manifest
+	manifest := &Manifest{
+		Entries: map[string]ManifestEntry{
+			"file1.tar.gz": {
+				Type:     EntryTypeDist,
+				Filename: "file1.tar.gz",
+				Size:     1000,
+				Checksums: Checksums{
+					SHA256: "abc123",
+					SHA512: "def456",
+				},
+			},
+			"file2.tar.gz": {
+				Type:     EntryTypeDist,
+				Filename: "file2.tar.gz",
+				Size:     2000,
+				Checksums: Checksums{
+					SHA256: "ghi789",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		entries []repo.SrcURIEntry
+		wantLen int
+		wantErr bool
+	}{
+		{
+			name: "single entry",
+			entries: []repo.SrcURIEntry{
+				{URL: "https://example.com/file1.tar.gz", Filename: "file1.tar.gz"},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "multiple entries",
+			entries: []repo.SrcURIEntry{
+				{URL: "https://example.com/file1.tar.gz", Filename: "file1.tar.gz"},
+				{URL: "https://example.com/file2.tar.gz", Filename: "file2.tar.gz"},
+			},
+			wantLen: 2,
+		},
+		{
+			name: "duplicate filenames deduplicated",
+			entries: []repo.SrcURIEntry{
+				{URL: "https://example.com/file1.tar.gz", Filename: "file1.tar.gz"},
+				{URL: "https://mirror.com/file1.tar.gz", Filename: "file1.tar.gz"},
+			},
+			wantLen: 1,
+		},
+		{
+			name: "missing from manifest",
+			entries: []repo.SrcURIEntry{
+				{URL: "https://example.com/unknown.tar.gz", Filename: "unknown.tar.gz"},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "empty entries",
+			entries: []repo.SrcURIEntry{},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fetcher := NewSrcURIFetcher(DefaultConfig())
+
+			distfiles, err := fetcher.entriesToDistfiles(tt.entries, manifest)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("entriesToDistfiles() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr && len(distfiles) != tt.wantLen {
+				t.Fatalf("got %d distfiles, want %d", len(distfiles), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestSrcURIFetcher_entriesToDistfiles_PreservesURIs(t *testing.T) {
+	t.Parallel()
+
+	manifest := &Manifest{
+		Entries: map[string]ManifestEntry{
+			"file.tar.gz": {
+				Type:     EntryTypeDist,
+				Filename: "file.tar.gz",
+				Size:     1000,
+				Checksums: Checksums{
+					SHA256: "abc123",
+				},
+			},
+		},
+	}
+
+	entries := []repo.SrcURIEntry{
+		{
+			URL:      "https://example.com/custom/path/file.tar.gz",
+			Filename: "file.tar.gz",
+		},
+	}
+
+	fetcher := NewSrcURIFetcher(DefaultConfig())
+	distfiles, err := fetcher.entriesToDistfiles(entries, manifest)
+
+	if err != nil {
+		t.Fatalf("entriesToDistfiles() error = %v", err)
+	}
+
+	if len(distfiles) != 1 {
+		t.Fatalf("got %d distfiles, want 1", len(distfiles))
+	}
+
+	if len(distfiles[0].URIs) != 1 {
+		t.Fatalf("got %d URIs, want 1", len(distfiles[0].URIs))
+	}
+
+	if distfiles[0].URIs[0] != "https://example.com/custom/path/file.tar.gz" {
+		t.Errorf("URI = %q, want %q", distfiles[0].URIs[0], "https://example.com/custom/path/file.tar.gz")
+	}
+}
+
+func TestSrcURIFetcher_entriesToDistfiles_ChecksumPreserved(t *testing.T) {
+	t.Parallel()
+
+	manifest := &Manifest{
+		Entries: map[string]ManifestEntry{
+			"file.tar.gz": {
+				Type:     EntryTypeDist,
+				Filename: "file.tar.gz",
+				Size:     12345,
+				Checksums: Checksums{
+					SHA256:  "sha256hash",
+					SHA512:  "sha512hash",
+					BLAKE2B: "blake2bhash",
+				},
+			},
+		},
+	}
+
+	entries := []repo.SrcURIEntry{
+		{URL: "https://example.com/file.tar.gz", Filename: "file.tar.gz"},
+	}
+
+	fetcher := NewSrcURIFetcher(DefaultConfig())
+	distfiles, err := fetcher.entriesToDistfiles(entries, manifest)
+
+	if err != nil {
+		t.Fatalf("entriesToDistfiles() error = %v", err)
+	}
+
+	if len(distfiles) != 1 {
+		t.Fatalf("got %d distfiles, want 1", len(distfiles))
+	}
+
+	d := distfiles[0]
+
+	if d.Filename != "file.tar.gz" {
+		t.Errorf("Filename = %q, want %q", d.Filename, "file.tar.gz")
+	}
+
+	if d.Size != 12345 {
+		t.Errorf("Size = %d, want %d", d.Size, 12345)
+	}
+
+	if d.Checksums.SHA256 != "sha256hash" {
+		t.Errorf("SHA256 = %q, want %q", d.Checksums.SHA256, "sha256hash")
+	}
+
+	if d.Checksums.SHA512 != "sha512hash" {
+		t.Errorf("SHA512 = %q, want %q", d.Checksums.SHA512, "sha512hash")
+	}
+
+	if d.Checksums.BLAKE2B != "blake2bhash" {
+		t.Errorf("BLAKE2B = %q, want %q", d.Checksums.BLAKE2B, "blake2bhash")
+	}
+}
+
+func TestNewSrcURIFetcher(t *testing.T) {
+	t.Parallel()
+
+	config := DefaultConfig().WithMirrors([]string{"https://mirror.example.com/"})
+
+	fetcher := NewSrcURIFetcher(config)
+
+	if fetcher == nil {
+		t.Fatal("NewSrcURIFetcher() returned nil")
+	}
+
+	if fetcher.downloader == nil {
+		t.Error("downloader is nil")
+	}
+
+	if fetcher.config.DistDir != config.DistDir {
+		t.Errorf("DistDir = %q, want %q", fetcher.config.DistDir, config.DistDir)
+	}
+}

--- a/internal/pkg/required_use.go
+++ b/internal/pkg/required_use.go
@@ -1,0 +1,417 @@
+package pkg
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RequiredUseError represents an error in REQUIRED_USE validation.
+type RequiredUseError struct {
+	Expression string
+	Reason     string
+}
+
+func (e *RequiredUseError) Error() string {
+	return fmt.Sprintf("REQUIRED_USE violation: %s (expression: %s)", e.Reason, e.Expression)
+}
+
+// RequiredUseValidator validates REQUIRED_USE expressions against enabled USE flags.
+// Implements PMS Section 7.2.6 REQUIRED_USE syntax:
+//   - flag: flag must be enabled
+//   - !flag: flag must be disabled
+//   - flag1? ( expr ): if flag1 is enabled, expr must be satisfied
+//   - !flag1? ( expr ): if flag1 is disabled, expr must be satisfied
+//   - || ( expr1 expr2 ... ): at least one of the expressions must be satisfied
+//   - ^^ ( expr1 expr2 ... ): exactly one of the expressions must be satisfied
+//   - ?? ( expr1 expr2 ... ): at most one of the expressions may be satisfied
+type RequiredUseValidator struct {
+	activeFlags map[string]bool
+}
+
+// NewRequiredUseValidator creates a new REQUIRED_USE validator.
+func NewRequiredUseValidator() *RequiredUseValidator {
+	return &RequiredUseValidator{
+		activeFlags: make(map[string]bool),
+	}
+}
+
+// Validate checks if the enabled USE flags satisfy the REQUIRED_USE expression.
+// Returns nil if validation passes, or an error describing the violation.
+func (v *RequiredUseValidator) Validate(expr string, enabledFlags []string) error {
+	if expr == "" {
+		return nil
+	}
+
+	// Build active flags map
+	v.activeFlags = make(map[string]bool)
+	for _, flag := range enabledFlags {
+		v.activeFlags[flag] = true
+	}
+
+	// Tokenize and parse
+	tokens := v.tokenize(expr)
+	satisfied, _, err := v.parseAndEvaluate(tokens, 0)
+	if err != nil {
+		return err
+	}
+
+	if !satisfied {
+		return &RequiredUseError{
+			Expression: expr,
+			Reason:     "USE flag constraints not satisfied",
+		}
+	}
+
+	return nil
+}
+
+// isEnabled checks if a flag is enabled.
+func (v *RequiredUseValidator) isEnabled(flag string) bool {
+	return v.activeFlags[flag]
+}
+
+// tokenize splits REQUIRED_USE expression into tokens.
+func (v *RequiredUseValidator) tokenize(expr string) []string {
+	var tokens []string
+	var current strings.Builder
+
+	for _, ch := range expr {
+		switch ch {
+		case '(', ')':
+			if current.Len() > 0 {
+				tokens = append(tokens, strings.TrimSpace(current.String()))
+				current.Reset()
+			}
+			tokens = append(tokens, string(ch))
+		case ' ', '\t', '\n':
+			if current.Len() > 0 {
+				tokens = append(tokens, strings.TrimSpace(current.String()))
+				current.Reset()
+			}
+		default:
+			current.WriteRune(ch)
+		}
+	}
+
+	if current.Len() > 0 {
+		tokens = append(tokens, strings.TrimSpace(current.String()))
+	}
+
+	return tokens
+}
+
+// parseAndEvaluate recursively parses and evaluates REQUIRED_USE tokens.
+// Returns (satisfied, nextIndex, error).
+func (v *RequiredUseValidator) parseAndEvaluate(tokens []string, start int) (bool, int, error) {
+	allSatisfied := true
+	i := start
+
+	for i < len(tokens) {
+		token := tokens[i]
+
+		if token == ")" {
+			return allSatisfied, i + 1, nil
+		}
+
+		satisfied, nextIdx, err := v.evaluateToken(tokens, i)
+		if err != nil {
+			return false, 0, err
+		}
+		allSatisfied = allSatisfied && satisfied
+		i = nextIdx
+	}
+
+	return allSatisfied, i, nil
+}
+
+// evaluateToken evaluates a single token and returns (satisfied, nextIndex, error).
+func (v *RequiredUseValidator) evaluateToken(tokens []string, i int) (bool, int, error) {
+	token := tokens[i]
+
+	// Handle nested parenthesis
+	if token == "(" {
+		return v.parseAndEvaluate(tokens, i+1)
+	}
+
+	// Handle operators ||, ^^, ??
+	if satisfied, nextIdx, handled, err := v.handleOperator(tokens, i); handled {
+		return satisfied, nextIdx, err
+	}
+
+	// Handle conditional: flag? ( ... ) or !flag? ( ... )
+	if strings.HasSuffix(token, "?") {
+		return v.handleConditionalInParse(tokens, i)
+	}
+
+	// Handle simple flag or !flag
+	return v.evaluateSimpleFlag(token), i + 1, nil
+}
+
+// handleOperator handles ||, ^^, ?? operators.
+// Returns (satisfied, nextIndex, handled, error).
+func (v *RequiredUseValidator) handleOperator(tokens []string, i int) (bool, int, bool, error) {
+	token := tokens[i]
+
+	type operatorHandler func([]string, int) (bool, int, error)
+	operators := map[string]operatorHandler{
+		"||": v.evaluateAnyOf,
+		"^^": v.evaluateExactlyOne,
+		"??": v.evaluateAtMostOne,
+	}
+
+	handler, isOperator := operators[token]
+	if !isOperator {
+		return false, 0, false, nil
+	}
+
+	if i+1 >= len(tokens) || tokens[i+1] != "(" {
+		return false, 0, true, fmt.Errorf("%s operator must be followed by (", token)
+	}
+
+	satisfied, nextIdx, err := handler(tokens, i+2)
+	return satisfied, nextIdx, true, err
+}
+
+// handleConditionalInParse handles flag? ( ... ) or !flag? ( ... ) in parseAndEvaluate.
+func (v *RequiredUseValidator) handleConditionalInParse(tokens []string, i int) (bool, int, error) {
+	token := tokens[i]
+	flagExpr := strings.TrimSuffix(token, "?")
+	negated := strings.HasPrefix(flagExpr, "!")
+	if negated {
+		flagExpr = strings.TrimPrefix(flagExpr, "!")
+	}
+
+	conditionMet := v.isEnabled(flagExpr)
+	if negated {
+		conditionMet = !conditionMet
+	}
+
+	if i+1 >= len(tokens) || tokens[i+1] != "(" {
+		return false, 0, fmt.Errorf("conditional %s must be followed by (", token)
+	}
+
+	if conditionMet {
+		return v.parseAndEvaluate(tokens, i+2)
+	}
+
+	// Skip the inner expression - condition not met
+	nextIdx, err := v.skipGroup(tokens, i+2)
+	return true, nextIdx, err
+}
+
+// evaluateAnyOf evaluates || ( ... ) - at least one must be satisfied.
+func (v *RequiredUseValidator) evaluateAnyOf(tokens []string, start int) (bool, int, error) {
+	satisfiedCount := 0
+	i := start
+
+	for i < len(tokens) {
+		token := tokens[i]
+
+		if token == ")" {
+			return satisfiedCount > 0, i + 1, nil
+		}
+
+		if token == "(" {
+			// Nested group
+			satisfied, nextIdx, err := v.parseAndEvaluate(tokens, i+1)
+			if err != nil {
+				return false, 0, err
+			}
+			if satisfied {
+				satisfiedCount++
+			}
+			i = nextIdx
+			continue
+		}
+
+		// Handle conditional in OR group
+		if strings.HasSuffix(token, "?") {
+			satisfied, nextIdx, err := v.evaluateConditional(tokens, i)
+			if err != nil {
+				return false, 0, err
+			}
+			if satisfied {
+				satisfiedCount++
+			}
+			i = nextIdx
+			continue
+		}
+
+		// Simple flag
+		if v.evaluateSimpleFlag(token) {
+			satisfiedCount++
+		}
+		i++
+	}
+
+	return satisfiedCount > 0, i, nil
+}
+
+// evaluateExactlyOne evaluates ^^ ( ... ) - exactly one must be satisfied.
+func (v *RequiredUseValidator) evaluateExactlyOne(tokens []string, start int) (bool, int, error) {
+	satisfiedCount := 0
+	i := start
+
+	for i < len(tokens) {
+		token := tokens[i]
+
+		if token == ")" {
+			return satisfiedCount == 1, i + 1, nil
+		}
+
+		if token == "(" {
+			// Nested group
+			satisfied, nextIdx, err := v.parseAndEvaluate(tokens, i+1)
+			if err != nil {
+				return false, 0, err
+			}
+			if satisfied {
+				satisfiedCount++
+			}
+			i = nextIdx
+			continue
+		}
+
+		// Handle conditional in XOR group
+		if strings.HasSuffix(token, "?") {
+			satisfied, nextIdx, err := v.evaluateConditional(tokens, i)
+			if err != nil {
+				return false, 0, err
+			}
+			if satisfied {
+				satisfiedCount++
+			}
+			i = nextIdx
+			continue
+		}
+
+		// Simple flag
+		if v.evaluateSimpleFlag(token) {
+			satisfiedCount++
+		}
+		i++
+	}
+
+	return satisfiedCount == 1, i, nil
+}
+
+// evaluateAtMostOne evaluates ?? ( ... ) - at most one may be satisfied.
+func (v *RequiredUseValidator) evaluateAtMostOne(tokens []string, start int) (bool, int, error) {
+	satisfiedCount := 0
+	i := start
+
+	for i < len(tokens) {
+		token := tokens[i]
+
+		if token == ")" {
+			return satisfiedCount <= 1, i + 1, nil
+		}
+
+		if token == "(" {
+			// Nested group
+			satisfied, nextIdx, err := v.parseAndEvaluate(tokens, i+1)
+			if err != nil {
+				return false, 0, err
+			}
+			if satisfied {
+				satisfiedCount++
+			}
+			i = nextIdx
+			continue
+		}
+
+		// Handle conditional in at-most-one group
+		if strings.HasSuffix(token, "?") {
+			satisfied, nextIdx, err := v.evaluateConditional(tokens, i)
+			if err != nil {
+				return false, 0, err
+			}
+			if satisfied {
+				satisfiedCount++
+			}
+			i = nextIdx
+			continue
+		}
+
+		// Simple flag
+		if v.evaluateSimpleFlag(token) {
+			satisfiedCount++
+		}
+		i++
+	}
+
+	return satisfiedCount <= 1, i, nil
+}
+
+// evaluateConditional evaluates a conditional expression: flag? ( ... ) or !flag? ( ... )
+func (v *RequiredUseValidator) evaluateConditional(tokens []string, start int) (bool, int, error) {
+	token := tokens[start]
+	flagExpr := strings.TrimSuffix(token, "?")
+	negated := strings.HasPrefix(flagExpr, "!")
+	if negated {
+		flagExpr = strings.TrimPrefix(flagExpr, "!")
+	}
+
+	// Check if condition applies
+	conditionMet := v.isEnabled(flagExpr)
+	if negated {
+		conditionMet = !conditionMet
+	}
+
+	// Must be followed by ( ... )
+	if start+1 >= len(tokens) || tokens[start+1] != "(" {
+		return false, 0, fmt.Errorf("conditional %s must be followed by (", token)
+	}
+
+	if conditionMet {
+		// Evaluate the inner expression
+		return v.parseAndEvaluate(tokens, start+2)
+	}
+
+	// Skip the inner expression - condition not met, so this branch is satisfied
+	nextIdx, err := v.skipGroup(tokens, start+2)
+	if err != nil {
+		return false, 0, err
+	}
+	return true, nextIdx, nil
+}
+
+// evaluateSimpleFlag evaluates a simple flag or !flag expression.
+func (v *RequiredUseValidator) evaluateSimpleFlag(token string) bool {
+	if strings.HasPrefix(token, "!") {
+		// !flag: satisfied if flag is disabled
+		flag := strings.TrimPrefix(token, "!")
+		return !v.isEnabled(flag)
+	}
+	// flag: satisfied if flag is enabled
+	return v.isEnabled(token)
+}
+
+// skipGroup skips over a parenthesized group without evaluation.
+func (v *RequiredUseValidator) skipGroup(tokens []string, start int) (int, error) {
+	depth := 1
+	i := start
+
+	for i < len(tokens) && depth > 0 {
+		switch tokens[i] {
+		case "(":
+			depth++
+		case ")":
+			depth--
+		}
+		i++
+	}
+
+	if depth != 0 {
+		return 0, fmt.Errorf("unbalanced parentheses in REQUIRED_USE")
+	}
+
+	return i, nil
+}
+
+// ValidateRequiredUse is a convenience function for validating REQUIRED_USE expressions.
+// It creates a validator and validates the expression against the given flags.
+func ValidateRequiredUse(expr string, enabledFlags []string) error {
+	validator := NewRequiredUseValidator()
+	return validator.Validate(expr, enabledFlags)
+}

--- a/internal/pkg/required_use_test.go
+++ b/internal/pkg/required_use_test.go
@@ -1,0 +1,431 @@
+package pkg
+
+import (
+	"testing"
+)
+
+func TestRequiredUseValidator_SimpleFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		flags   []string
+		wantErr bool
+	}{
+		{
+			name:    "Single flag enabled",
+			expr:    "ssl",
+			flags:   []string{"ssl"},
+			wantErr: false,
+		},
+		{
+			name:    "Single flag disabled",
+			expr:    "ssl",
+			flags:   []string{},
+			wantErr: true,
+		},
+		{
+			name:    "Negated flag - flag disabled",
+			expr:    "!debug",
+			flags:   []string{"ssl"},
+			wantErr: false,
+		},
+		{
+			name:    "Negated flag - flag enabled",
+			expr:    "!debug",
+			flags:   []string{"debug"},
+			wantErr: true,
+		},
+		{
+			name:    "Multiple flags - all enabled",
+			expr:    "ssl gnutls",
+			flags:   []string{"ssl", "gnutls"},
+			wantErr: false,
+		},
+		{
+			name:    "Multiple flags - one missing",
+			expr:    "ssl gnutls",
+			flags:   []string{"ssl"},
+			wantErr: true,
+		},
+		{
+			name:    "Empty expression",
+			expr:    "",
+			flags:   []string{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewRequiredUseValidator()
+			err := v.Validate(tt.expr, tt.flags)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRequiredUseValidator_AnyOf(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		flags   []string
+		wantErr bool
+	}{
+		{
+			name:    "Any-of: one enabled",
+			expr:    "|| ( ssl gnutls )",
+			flags:   []string{"ssl"},
+			wantErr: false,
+		},
+		{
+			name:    "Any-of: other enabled",
+			expr:    "|| ( ssl gnutls )",
+			flags:   []string{"gnutls"},
+			wantErr: false,
+		},
+		{
+			name:    "Any-of: both enabled",
+			expr:    "|| ( ssl gnutls )",
+			flags:   []string{"ssl", "gnutls"},
+			wantErr: false,
+		},
+		{
+			name:    "Any-of: none enabled",
+			expr:    "|| ( ssl gnutls )",
+			flags:   []string{},
+			wantErr: true,
+		},
+		{
+			name:    "Any-of: three options, one enabled",
+			expr:    "|| ( mysql postgres sqlite )",
+			flags:   []string{"sqlite"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewRequiredUseValidator()
+			err := v.Validate(tt.expr, tt.flags)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRequiredUseValidator_ExactlyOne(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		flags   []string
+		wantErr bool
+	}{
+		{
+			name:    "Exactly-one: one enabled",
+			expr:    "^^ ( ssl gnutls )",
+			flags:   []string{"ssl"},
+			wantErr: false,
+		},
+		{
+			name:    "Exactly-one: other enabled",
+			expr:    "^^ ( ssl gnutls )",
+			flags:   []string{"gnutls"},
+			wantErr: false,
+		},
+		{
+			name:    "Exactly-one: both enabled (invalid)",
+			expr:    "^^ ( ssl gnutls )",
+			flags:   []string{"ssl", "gnutls"},
+			wantErr: true,
+		},
+		{
+			name:    "Exactly-one: none enabled (invalid)",
+			expr:    "^^ ( ssl gnutls )",
+			flags:   []string{},
+			wantErr: true,
+		},
+		{
+			name:    "Exactly-one: three options, one enabled",
+			expr:    "^^ ( openssl gnutls libressl )",
+			flags:   []string{"openssl"},
+			wantErr: false,
+		},
+		{
+			name:    "Exactly-one: three options, two enabled (invalid)",
+			expr:    "^^ ( openssl gnutls libressl )",
+			flags:   []string{"openssl", "gnutls"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewRequiredUseValidator()
+			err := v.Validate(tt.expr, tt.flags)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRequiredUseValidator_AtMostOne(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		flags   []string
+		wantErr bool
+	}{
+		{
+			name:    "At-most-one: one enabled",
+			expr:    "?? ( ssl gnutls )",
+			flags:   []string{"ssl"},
+			wantErr: false,
+		},
+		{
+			name:    "At-most-one: none enabled",
+			expr:    "?? ( ssl gnutls )",
+			flags:   []string{},
+			wantErr: false,
+		},
+		{
+			name:    "At-most-one: both enabled (invalid)",
+			expr:    "?? ( ssl gnutls )",
+			flags:   []string{"ssl", "gnutls"},
+			wantErr: true,
+		},
+		{
+			name:    "At-most-one: three options, one enabled",
+			expr:    "?? ( mysql postgres sqlite )",
+			flags:   []string{"mysql"},
+			wantErr: false,
+		},
+		{
+			name:    "At-most-one: three options, two enabled (invalid)",
+			expr:    "?? ( mysql postgres sqlite )",
+			flags:   []string{"mysql", "postgres"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewRequiredUseValidator()
+			err := v.Validate(tt.expr, tt.flags)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRequiredUseValidator_Conditionals(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		flags   []string
+		wantErr bool
+	}{
+		{
+			name:    "Conditional: condition not met, skipped",
+			expr:    "ssl? ( gnutls )",
+			flags:   []string{},
+			wantErr: false, // ssl not enabled, so gnutls not required
+		},
+		{
+			name:    "Conditional: condition met, inner satisfied",
+			expr:    "ssl? ( gnutls )",
+			flags:   []string{"ssl", "gnutls"},
+			wantErr: false,
+		},
+		{
+			name:    "Conditional: condition met, inner not satisfied",
+			expr:    "ssl? ( gnutls )",
+			flags:   []string{"ssl"},
+			wantErr: true, // ssl enabled but gnutls not
+		},
+		{
+			name:    "Negated conditional: condition not met, inner evaluated",
+			expr:    "!ssl? ( gnutls )",
+			flags:   []string{"gnutls"},
+			wantErr: false, // ssl not enabled, gnutls required and enabled
+		},
+		{
+			name:    "Negated conditional: condition met, skipped",
+			expr:    "!ssl? ( gnutls )",
+			flags:   []string{"ssl"},
+			wantErr: false, // ssl enabled, gnutls not required
+		},
+		{
+			name:    "Negated conditional: condition not met, inner not satisfied",
+			expr:    "!ssl? ( gnutls )",
+			flags:   []string{},
+			wantErr: true, // ssl not enabled, gnutls required but not enabled
+		},
+		{
+			name:    "Conditional with negated inner",
+			expr:    "ssl? ( !gnutls )",
+			flags:   []string{"ssl"},
+			wantErr: false, // ssl enabled, gnutls not enabled (satisfied)
+		},
+		{
+			name:    "Conditional with negated inner - violation",
+			expr:    "ssl? ( !gnutls )",
+			flags:   []string{"ssl", "gnutls"},
+			wantErr: true, // ssl enabled, gnutls should be disabled but is enabled
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewRequiredUseValidator()
+			err := v.Validate(tt.expr, tt.flags)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRequiredUseValidator_Complex(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		flags   []string
+		wantErr bool
+	}{
+		{
+			name:    "Combined: simple + any-of",
+			expr:    "python || ( ssl gnutls )",
+			flags:   []string{"python", "ssl"},
+			wantErr: false,
+		},
+		{
+			name:    "Combined: simple missing",
+			expr:    "python || ( ssl gnutls )",
+			flags:   []string{"ssl"},
+			wantErr: true,
+		},
+		{
+			name:    "Combined: any-of not satisfied",
+			expr:    "python || ( ssl gnutls )",
+			flags:   []string{"python"},
+			wantErr: true,
+		},
+		{
+			name:    "Multiple operators",
+			expr:    "^^ ( ssl gnutls ) || ( mysql postgres )",
+			flags:   []string{"ssl", "postgres"},
+			wantErr: false,
+		},
+		{
+			name:    "Real-world: audio backend selection",
+			expr:    "^^ ( alsa pulseaudio pipewire )",
+			flags:   []string{"pipewire"},
+			wantErr: false,
+		},
+		{
+			name:    "Real-world: SSL provider",
+			expr:    "ssl? ( ^^ ( openssl gnutls libressl ) )",
+			flags:   []string{"ssl", "openssl"},
+			wantErr: false,
+		},
+		{
+			name:    "Real-world: SSL provider - ssl not enabled",
+			expr:    "ssl? ( ^^ ( openssl gnutls libressl ) )",
+			flags:   []string{},
+			wantErr: false, // ssl not enabled, inner not evaluated
+		},
+		{
+			name:    "Real-world: SSL provider - ssl enabled, no provider",
+			expr:    "ssl? ( ^^ ( openssl gnutls libressl ) )",
+			flags:   []string{"ssl"},
+			wantErr: true, // ssl enabled, exactly one provider needed
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := NewRequiredUseValidator()
+			err := v.Validate(tt.expr, tt.flags)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRequiredUseError(t *testing.T) {
+	err := &RequiredUseError{
+		Expression: "|| ( ssl gnutls )",
+		Reason:     "USE flag constraints not satisfied",
+	}
+
+	expected := "REQUIRED_USE violation: USE flag constraints not satisfied (expression: || ( ssl gnutls ))"
+	if err.Error() != expected {
+		t.Errorf("Error() = %q, want %q", err.Error(), expected)
+	}
+}
+
+func TestValidateRequiredUse_ConvenienceFunction(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		flags   []string
+		wantErr bool
+	}{
+		{
+			name:    "Valid expression",
+			expr:    "|| ( ssl gnutls )",
+			flags:   []string{"ssl"},
+			wantErr: false,
+		},
+		{
+			name:    "Invalid expression",
+			expr:    "|| ( ssl gnutls )",
+			flags:   []string{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRequiredUse(tt.expr, tt.flags)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateRequiredUse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func BenchmarkRequiredUseValidator_Simple(b *testing.B) {
+	expr := "ssl gnutls python"
+	flags := []string{"ssl", "gnutls", "python"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v := NewRequiredUseValidator()
+		_ = v.Validate(expr, flags)
+	}
+}
+
+func BenchmarkRequiredUseValidator_Complex(b *testing.B) {
+	expr := "ssl? ( ^^ ( openssl gnutls libressl ) ) || ( mysql postgres sqlite )"
+	flags := []string{"ssl", "openssl", "mysql"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v := NewRequiredUseValidator()
+		_ = v.Validate(expr, flags)
+	}
+}

--- a/internal/repo/atom_integration_test.go
+++ b/internal/repo/atom_integration_test.go
@@ -1,0 +1,323 @@
+package repo
+
+import (
+	"testing"
+
+	"github.com/grpmsoft/grpm/internal/pkg"
+)
+
+// TestParseAtomIntegration tests that ebuild parser correctly uses pkg.ParseAtom
+func TestParseAtomIntegration(t *testing.T) {
+	tests := []struct {
+		name         string
+		atomStr      string
+		wantCategory string
+		wantPackage  string
+		wantVersion  string
+		wantSlot     string
+		wantBlocker  bool
+	}{
+		{
+			name:         "simple atom",
+			atomStr:      "sys-libs/zlib",
+			wantCategory: "sys-libs",
+			wantPackage:  "zlib",
+		},
+		{
+			name:         "versioned atom",
+			atomStr:      ">=sys-libs/zlib-1.2.13",
+			wantCategory: "sys-libs",
+			wantPackage:  "zlib",
+			wantVersion:  "1.2.13",
+		},
+		{
+			name:         "slotted atom",
+			atomStr:      "dev-lang/python:3.12",
+			wantCategory: "dev-lang",
+			wantPackage:  "python",
+			wantSlot:     "3.12",
+		},
+		{
+			name:         "versioned and slotted",
+			atomStr:      ">=dev-libs/openssl-3.0:0",
+			wantCategory: "dev-libs",
+			wantPackage:  "openssl",
+			wantVersion:  "3.0",
+			wantSlot:     "0",
+		},
+		{
+			name:         "blocker",
+			atomStr:      "!sys-libs/uclibc",
+			wantCategory: "sys-libs",
+			wantPackage:  "uclibc",
+			wantBlocker:  true,
+		},
+		{
+			name:         "strong blocker",
+			atomStr:      "!!app-misc/old-pkg",
+			wantCategory: "app-misc",
+			wantPackage:  "old-pkg",
+			wantBlocker:  true,
+		},
+	}
+
+	parser := &EbuildParser{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dep, err := parser.parsePackageAtom(tt.atomStr, DepTypeRuntime, "", 0)
+			if err != nil {
+				t.Fatalf("parsePackageAtom(%q) error: %v", tt.atomStr, err)
+			}
+
+			// Check that Atom was populated (for valid atoms)
+			if dep.Atom != nil {
+				if dep.Atom.Category != tt.wantCategory {
+					t.Errorf("Atom.Category = %q, want %q", dep.Atom.Category, tt.wantCategory)
+				}
+				if dep.Atom.Package != tt.wantPackage {
+					t.Errorf("Atom.Package = %q, want %q", dep.Atom.Package, tt.wantPackage)
+				}
+				if tt.wantVersion != "" && dep.Atom.Version != tt.wantVersion {
+					t.Errorf("Atom.Version = %q, want %q", dep.Atom.Version, tt.wantVersion)
+				}
+				if tt.wantSlot != "" && dep.Atom.Slot != tt.wantSlot {
+					t.Errorf("Atom.Slot = %q, want %q", dep.Atom.Slot, tt.wantSlot)
+				}
+				if dep.Atom.IsBlocker() != tt.wantBlocker {
+					t.Errorf("Atom.IsBlocker() = %v, want %v", dep.Atom.IsBlocker(), tt.wantBlocker)
+				}
+			}
+
+			// Check that Constraint is populated for backward compatibility
+			expectedName := tt.wantCategory + "/" + tt.wantPackage
+			if dep.Constraint.Name != expectedName {
+				t.Errorf("Constraint.Name = %q, want %q", dep.Constraint.Name, expectedName)
+			}
+
+			// Check blocker flags
+			if dep.IsBlocker != tt.wantBlocker {
+				t.Errorf("IsBlocker = %v, want %v", dep.IsBlocker, tt.wantBlocker)
+			}
+		})
+	}
+}
+
+// TestParseAtomWithUSEFlags tests USE flag extraction via ParseAtom
+func TestParseAtomWithUSEFlags(t *testing.T) {
+	tests := []struct {
+		name           string
+		atomStr        string
+		wantCondition  string
+		hasAtom        bool
+		atomUseRequire []string
+		atomUseBlock   []string
+	}{
+		{
+			name:           "single USE flag",
+			atomStr:        "dev-libs/openssl[ssl]",
+			wantCondition:  "ssl",
+			hasAtom:        true,
+			atomUseRequire: []string{"ssl"},
+		},
+		{
+			name:          "blocked USE flag",
+			atomStr:       "sys-libs/glibc[-static]",
+			wantCondition: "-static",
+			hasAtom:       true,
+			atomUseBlock:  []string{"static"},
+		},
+		{
+			name:           "mixed USE flags",
+			atomStr:        "dev-lang/python[ssl,-tk,threads]",
+			wantCondition:  "ssl threads -tk",
+			hasAtom:        true,
+			atomUseRequire: []string{"ssl", "threads"},
+			atomUseBlock:   []string{"tk"},
+		},
+	}
+
+	parser := &EbuildParser{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dep, err := parser.parsePackageAtom(tt.atomStr, DepTypeRuntime, "", 0)
+			if err != nil {
+				t.Fatalf("parsePackageAtom(%q) error: %v", tt.atomStr, err)
+			}
+
+			// Check Constraint.Condition for backward compatibility
+			if dep.Constraint.Condition != tt.wantCondition {
+				t.Errorf("Constraint.Condition = %q, want %q", dep.Constraint.Condition, tt.wantCondition)
+			}
+
+			// Check Atom USE deps
+			if tt.hasAtom && dep.Atom != nil {
+				if len(tt.atomUseRequire) > 0 && !stringSlicesEqual(dep.Atom.UseRequire, tt.atomUseRequire) {
+					t.Errorf("Atom.UseRequire = %v, want %v", dep.Atom.UseRequire, tt.atomUseRequire)
+				}
+				if len(tt.atomUseBlock) > 0 && !stringSlicesEqual(dep.Atom.UseBlock, tt.atomUseBlock) {
+					t.Errorf("Atom.UseBlock = %v, want %v", dep.Atom.UseBlock, tt.atomUseBlock)
+				}
+			}
+		})
+	}
+}
+
+// TestFindByAtomMockRepo tests FindByAtom on MockRepository
+func TestFindByAtomMockRepo(t *testing.T) {
+	repo := NewMockRepository()
+
+	tests := []struct {
+		name        string
+		atomStr     string
+		wantMatches int
+	}{
+		{
+			name:        "find existing package",
+			atomStr:     "sys-libs/zlib",
+			wantMatches: 1,
+		},
+		{
+			name:        "find with version constraint",
+			atomStr:     ">=sys-libs/zlib-1.2.0",
+			wantMatches: 1,
+		},
+		{
+			name:        "find non-existent package",
+			atomStr:     "non-existent/package",
+			wantMatches: 0,
+		},
+		{
+			name:        "find hello package",
+			atomStr:     "app-misc/hello",
+			wantMatches: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			atom, err := pkg.ParseAtom(tt.atomStr)
+			if err != nil {
+				t.Fatalf("ParseAtom(%q) error: %v", tt.atomStr, err)
+			}
+
+			matches, err := repo.FindByAtom(atom)
+			if err != nil {
+				t.Fatalf("FindByAtom(%q) error: %v", tt.atomStr, err)
+			}
+
+			if len(matches) != tt.wantMatches {
+				t.Errorf("FindByAtom(%q) returned %d matches, want %d",
+					tt.atomStr, len(matches), tt.wantMatches)
+			}
+		})
+	}
+}
+
+// TestFindByAtomNilAtom tests FindByAtom with nil atom
+func TestFindByAtomNilAtom(t *testing.T) {
+	repo := NewMockRepository()
+
+	_, err := repo.FindByAtom(nil)
+	if err == nil {
+		t.Error("FindByAtom(nil) should return error")
+	}
+}
+
+// TestAtomToConstraintIntegration tests that Atom.ToConstraint produces valid constraints
+func TestAtomToConstraintIntegration(t *testing.T) {
+	tests := []struct {
+		name       string
+		atomStr    string
+		wantName   string
+		wantHasVer bool
+	}{
+		{
+			name:       "simple atom",
+			atomStr:    "sys-libs/glibc",
+			wantName:   "sys-libs/glibc",
+			wantHasVer: false,
+		},
+		{
+			name:       "versioned atom",
+			atomStr:    ">=sys-libs/glibc-2.38",
+			wantName:   "sys-libs/glibc",
+			wantHasVer: true,
+		},
+		{
+			name:       "exact version",
+			atomStr:    "=dev-lang/python-3.12",
+			wantName:   "dev-lang/python",
+			wantHasVer: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			atom, err := pkg.ParseAtom(tt.atomStr)
+			if err != nil {
+				t.Fatalf("ParseAtom(%q) error: %v", tt.atomStr, err)
+			}
+
+			constraint := atom.ToConstraint()
+
+			if constraint.Name != tt.wantName {
+				t.Errorf("ToConstraint().Name = %q, want %q", constraint.Name, tt.wantName)
+			}
+
+			hasVersion := constraint.Version != nil
+			if hasVersion != tt.wantHasVer {
+				t.Errorf("ToConstraint() has version = %v, want %v", hasVersion, tt.wantHasVer)
+			}
+		})
+	}
+}
+
+// TestParseDependencyStringWithAtoms tests full dependency parsing flow
+func TestParseDependencyStringWithAtoms(t *testing.T) {
+	content := `
+RDEPEND="
+	>=sys-libs/glibc-2.38
+	dev-libs/openssl:0[ssl,-static]
+	ssl? ( net-misc/curl )
+	|| ( sys-devel/gcc sys-devel/clang )
+"
+`
+
+	parser := NewEbuildParser(content)
+	deps, err := parser.ParseDependencies()
+	if err != nil {
+		t.Fatalf("ParseDependencies() error: %v", err)
+	}
+
+	// Should have at least 5 dependencies
+	if len(deps) < 5 {
+		t.Fatalf("ParseDependencies() returned %d deps, expected at least 5", len(deps))
+	}
+
+	// Check that atoms were populated
+	atomCount := 0
+	for _, dep := range deps {
+		if dep.Atom != nil {
+			atomCount++
+		}
+	}
+
+	if atomCount < 4 {
+		t.Errorf("Only %d dependencies have Atom populated, expected at least 4", atomCount)
+	}
+}
+
+// stringSlicesEqual compares two string slices
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/repo/ebuild_parser.go
+++ b/internal/repo/ebuild_parser.go
@@ -33,14 +33,17 @@ const (
 	DepTypeRuntime   DependencyType = iota // RDEPEND
 	DepTypeBuild                           // DEPEND
 	DepTypeBuildtime                       // BDEPEND
+	DepTypeInstall                         // IDEPEND (EAPI 8)
+	DepTypePostMerge                       // PDEPEND
 )
 
 // ParsedDependency represents a parsed dependency with all metadata
 type ParsedDependency struct {
-	Constraint  pkg.Constraint
-	UseFlag     string // USE flag condition (e.g., "ssl" for "ssl? ( ... )")
-	IsBlocker   bool   // true if starts with !
-	IsHardBlock bool   // true if starts with !!
+	Atom        *pkg.Atom      // PMS-compliant atom (preferred)
+	Constraint  pkg.Constraint // Legacy constraint (for backwards compatibility)
+	UseFlag     string         // USE flag condition (e.g., "ssl" for "ssl? ( ... )")
+	IsBlocker   bool           // true if starts with !
+	IsHardBlock bool           // true if starts with !!
 	DepType     DependencyType
 	OrGroupID   int // OR-group ID (0 = not in OR-group, >0 = OR alternative)
 }
@@ -168,6 +171,27 @@ func (ep *EbuildParser) ParseDependencies() ([]ParsedDependency, error) {
 		allDeps = append(allDeps, deps...)
 	}
 
+	// Parse IDEPEND (EAPI 8: install-time dependencies)
+	// These are dependencies needed by pkg_* phases at install time
+	idepend := ep.ExtractVariable("IDEPEND")
+	if idepend != "" {
+		deps, err := ep.parseDependencyString(idepend, DepTypeInstall)
+		if err != nil {
+			return nil, fmt.Errorf("parsing IDEPEND: %w", err)
+		}
+		allDeps = append(allDeps, deps...)
+	}
+
+	// Parse PDEPEND (post-merge dependencies)
+	pdepend := ep.ExtractVariable("PDEPEND")
+	if pdepend != "" {
+		deps, err := ep.parseDependencyString(pdepend, DepTypePostMerge)
+		if err != nil {
+			return nil, fmt.Errorf("parsing PDEPEND: %w", err)
+		}
+		allDeps = append(allDeps, deps...)
+	}
+
 	return allDeps, nil
 }
 
@@ -260,6 +284,55 @@ func (ep *EbuildParser) ExtractVariable(varName string) string {
 	expanded := ep.expandVariables(rawValue, 0)
 
 	return strings.TrimSpace(expanded)
+}
+
+// ExtractProperties extracts and parses the PROPERTIES variable from ebuild.
+// PROPERTIES values affect package manager behavior (PMS Section 7.2.7).
+// Common values: interactive, live, test_network
+func (ep *EbuildParser) ExtractProperties() []string {
+	props := ep.ExtractVariable("PROPERTIES")
+	if props == "" {
+		return nil
+	}
+	return parseSpaceSeparatedList(props)
+}
+
+// ExtractRestrict extracts and parses the RESTRICT variable from ebuild.
+// RESTRICT values limit package manager actions (PMS Section 7.2.8).
+// Common values: mirror, fetch, strip, test, userpriv, network-sandbox
+func (ep *EbuildParser) ExtractRestrict() []string {
+	restrict := ep.ExtractVariable("RESTRICT")
+	if restrict == "" {
+		return nil
+	}
+	return parseSpaceSeparatedList(restrict)
+}
+
+// ExtractRequiredUse extracts the REQUIRED_USE variable from ebuild.
+// REQUIRED_USE defines constraints on USE flag combinations (PMS Section 7.2.6).
+// Example: "|| ( ssl gnutls )" means at least one of ssl or gnutls must be enabled.
+func (ep *EbuildParser) ExtractRequiredUse() string {
+	return ep.ExtractVariable("REQUIRED_USE")
+}
+
+// parseSpaceSeparatedList splits a space-separated string into a slice.
+// Handles multiple whitespace and trims each element.
+func parseSpaceSeparatedList(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+
+	// Split on whitespace
+	fields := strings.Fields(s)
+	result := make([]string, 0, len(fields))
+	for _, f := range fields {
+		f = strings.TrimSpace(f)
+		if f != "" {
+			result = append(result, f)
+		}
+	}
+	return result
 }
 
 // parseDependencyString parses a dependency string (e.g., RDEPEND value)
@@ -388,8 +461,60 @@ func (ep *EbuildParser) isPackageAtom(token string) bool {
 	return token != "" && token != "(" && token != ")"
 }
 
-// parsePackageAtom parses a single package atom (e.g., ">=sys-libs/zlib-1.2.13:0/1[static-libs]")
-func (ep *EbuildParser) parsePackageAtom(atom string, depType DependencyType, useFlag string, orGroupID int) (ParsedDependency, error) {
+// parsePackageAtom parses a single package atom using pkg.ParseAtom (PMS Section 8.3).
+// Example: ">=sys-libs/zlib-1.2.13:0/1[static-libs]"
+func (ep *EbuildParser) parsePackageAtom(atomStr string, depType DependencyType, useFlag string, orGroupID int) (ParsedDependency, error) {
+	dep := ParsedDependency{
+		DepType:   depType,
+		UseFlag:   useFlag,
+		OrGroupID: orGroupID,
+	}
+
+	// Use the PMS-compliant atom parser
+	atom, err := pkg.ParseAtom(atomStr)
+	if err != nil {
+		// Fallback to legacy parsing for atoms that fail PMS parsing
+		// This handles edge cases like virtual packages or unusual patterns
+		return ep.parsePackageAtomLegacy(atomStr, depType, useFlag, orGroupID)
+	}
+
+	// Store the parsed atom
+	dep.Atom = atom
+
+	// Set blocker flags
+	dep.IsBlocker = atom.IsBlocker()
+	dep.IsHardBlock = atom.IsStrongBlocker()
+
+	// Convert atom to constraint for backwards compatibility
+	dep.Constraint = atom.ToConstraint()
+	dep.Constraint.OrGroupID = orGroupID
+
+	// Set slot from atom if present
+	if atom.HasSlot() {
+		dep.Constraint.Slot = atom.Slot
+		if atom.Subslot != "" {
+			dep.Constraint.Slot = atom.Slot + "/" + atom.Subslot
+		}
+		dep.Constraint.Type = pkg.ConstraintTypeSlot
+	}
+
+	// Store USE flags in Condition field
+	if atom.HasUseDeps() {
+		var useFlags []string
+		useFlags = append(useFlags, atom.UseRequire...)
+		for _, flag := range atom.UseBlock {
+			useFlags = append(useFlags, "-"+flag)
+		}
+		useFlags = append(useFlags, atom.UseConditional...)
+		dep.Constraint.Condition = strings.Join(useFlags, " ")
+	}
+
+	return dep, nil
+}
+
+// parsePackageAtomLegacy is the fallback parser for atoms that fail PMS parsing.
+// This handles edge cases and provides backward compatibility.
+func (ep *EbuildParser) parsePackageAtomLegacy(atom string, depType DependencyType, useFlag string, orGroupID int) (ParsedDependency, error) {
 	dep := ParsedDependency{
 		DepType:   depType,
 		UseFlag:   useFlag,

--- a/internal/repo/ebuild_parser_test.go
+++ b/internal/repo/ebuild_parser_test.go
@@ -1090,3 +1090,404 @@ RDEPEND=">=sys-libs/zlib-1.2.13"
 		_ = parser.ExtractVariable("SRC_URI")
 	}
 }
+
+// ==================== EAPI 8 Variables Tests ====================
+
+// TestIDEPENDParsing tests EAPI 8 IDEPEND parsing
+func TestIDEPENDParsing(t *testing.T) {
+	content := `
+EAPI=8
+IDEPEND="app-misc/pax-utils"
+`
+
+	parser := NewEbuildParser(content)
+	idepend := parser.ExtractVariable("IDEPEND")
+
+	if idepend != "app-misc/pax-utils" {
+		t.Errorf("IDEPEND = %q, expected %q", idepend, "app-misc/pax-utils")
+	}
+}
+
+// TestIDEPENDDependencyParsing tests IDEPEND is included in ParseDependencies
+func TestIDEPENDDependencyParsing(t *testing.T) {
+	content := `
+EAPI=8
+RDEPEND="sys-libs/zlib"
+IDEPEND="app-misc/pax-utils"
+`
+
+	parser := NewEbuildParser(content)
+	deps, err := parser.ParseDependencies()
+
+	if err != nil {
+		t.Fatalf("ParseDependencies() error: %v", err)
+	}
+
+	// Should have 2 dependencies: zlib (RDEPEND) and pax-utils (IDEPEND)
+	if len(deps) != 2 {
+		t.Fatalf("ParseDependencies() returned %d deps, expected 2", len(deps))
+	}
+
+	// Check that IDEPEND has correct type
+	var idependFound bool
+	for _, dep := range deps {
+		if contains(dep.Constraint.Name, "pax-utils") {
+			idependFound = true
+			if dep.DepType != DepTypeInstall {
+				t.Errorf("pax-utils should have DepTypeInstall, got %d", dep.DepType)
+			}
+		}
+	}
+
+	if !idependFound {
+		t.Error("Expected to find pax-utils in dependencies")
+	}
+}
+
+// TestPDEPENDParsing tests PDEPEND parsing
+func TestPDEPENDParsing(t *testing.T) {
+	content := `
+EAPI=8
+PDEPEND="app-misc/screen"
+`
+
+	parser := NewEbuildParser(content)
+	deps, err := parser.ParseDependencies()
+
+	if err != nil {
+		t.Fatalf("ParseDependencies() error: %v", err)
+	}
+
+	if len(deps) != 1 {
+		t.Fatalf("ParseDependencies() returned %d deps, expected 1", len(deps))
+	}
+
+	if deps[0].DepType != DepTypePostMerge {
+		t.Errorf("PDEPEND should have DepTypePostMerge, got %d", deps[0].DepType)
+	}
+}
+
+// TestAllDependencyTypes tests all dependency types are parsed correctly
+func TestAllDependencyTypes(t *testing.T) {
+	content := `
+EAPI=8
+RDEPEND="sys-libs/zlib"
+DEPEND="dev-libs/openssl"
+BDEPEND="sys-devel/gcc"
+IDEPEND="app-misc/pax-utils"
+PDEPEND="app-misc/screen"
+`
+
+	parser := NewEbuildParser(content)
+	deps, err := parser.ParseDependencies()
+
+	if err != nil {
+		t.Fatalf("ParseDependencies() error: %v", err)
+	}
+
+	// Should have 5 dependencies total
+	if len(deps) != 5 {
+		t.Fatalf("ParseDependencies() returned %d deps, expected 5", len(deps))
+	}
+
+	// Count each type
+	typeCounts := make(map[DependencyType]int)
+	for _, dep := range deps {
+		typeCounts[dep.DepType]++
+	}
+
+	expectedCounts := map[DependencyType]int{
+		DepTypeRuntime:   1,
+		DepTypeBuild:     1,
+		DepTypeBuildtime: 1,
+		DepTypeInstall:   1,
+		DepTypePostMerge: 1,
+	}
+
+	for depType, expected := range expectedCounts {
+		if typeCounts[depType] != expected {
+			t.Errorf("DepType %d: got %d, expected %d", depType, typeCounts[depType], expected)
+		}
+	}
+}
+
+// TestPropertiesParsing tests PROPERTIES extraction
+func TestPropertiesParsing(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected []string
+	}{
+		{
+			name: "Single property",
+			content: `
+PROPERTIES="interactive"
+`,
+			expected: []string{"interactive"},
+		},
+		{
+			name: "Multiple properties",
+			content: `
+PROPERTIES="interactive live"
+`,
+			expected: []string{"interactive", "live"},
+		},
+		{
+			name: "All common properties",
+			content: `
+PROPERTIES="interactive live test_network"
+`,
+			expected: []string{"interactive", "live", "test_network"},
+		},
+		{
+			name:     "Empty properties",
+			content:  ``,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := NewEbuildParser(tt.content)
+			props := parser.ExtractProperties()
+
+			if len(props) != len(tt.expected) {
+				t.Errorf("ExtractProperties() returned %d items, expected %d", len(props), len(tt.expected))
+				return
+			}
+
+			for i, expected := range tt.expected {
+				if props[i] != expected {
+					t.Errorf("Properties[%d] = %q, expected %q", i, props[i], expected)
+				}
+			}
+		})
+	}
+}
+
+// TestRestrictParsing tests RESTRICT extraction
+func TestRestrictParsing(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected []string
+	}{
+		{
+			name: "Single restrict",
+			content: `
+RESTRICT="mirror"
+`,
+			expected: []string{"mirror"},
+		},
+		{
+			name: "Multiple restricts",
+			content: `
+RESTRICT="mirror fetch"
+`,
+			expected: []string{"mirror", "fetch"},
+		},
+		{
+			name: "All common restricts",
+			content: `
+RESTRICT="mirror fetch strip test userpriv network-sandbox"
+`,
+			expected: []string{"mirror", "fetch", "strip", "test", "userpriv", "network-sandbox"},
+		},
+		{
+			name:     "Empty restrict",
+			content:  ``,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := NewEbuildParser(tt.content)
+			restrict := parser.ExtractRestrict()
+
+			if len(restrict) != len(tt.expected) {
+				t.Errorf("ExtractRestrict() returned %d items, expected %d", len(restrict), len(tt.expected))
+				return
+			}
+
+			for i, expected := range tt.expected {
+				if restrict[i] != expected {
+					t.Errorf("Restrict[%d] = %q, expected %q", i, restrict[i], expected)
+				}
+			}
+		})
+	}
+}
+
+// TestRequiredUseParsing tests REQUIRED_USE extraction
+func TestRequiredUseParsing(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			name: "Simple any-of",
+			content: `
+REQUIRED_USE="|| ( ssl gnutls )"
+`,
+			expected: "|| ( ssl gnutls )",
+		},
+		{
+			name: "Exactly-one",
+			content: `
+REQUIRED_USE="^^ ( openssl gnutls libressl )"
+`,
+			expected: "^^ ( openssl gnutls libressl )",
+		},
+		{
+			name: "Complex expression",
+			content: `
+REQUIRED_USE="ssl? ( ^^ ( openssl gnutls ) )"
+`,
+			expected: "ssl? ( ^^ ( openssl gnutls ) )",
+		},
+		{
+			name:     "Empty",
+			content:  ``,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := NewEbuildParser(tt.content)
+			requiredUse := parser.ExtractRequiredUse()
+
+			if requiredUse != tt.expected {
+				t.Errorf("ExtractRequiredUse() = %q, expected %q", requiredUse, tt.expected)
+			}
+		})
+	}
+}
+
+// TestRealWorldEAPI8Ebuild tests parsing a real-world EAPI 8 ebuild
+func TestRealWorldEAPI8Ebuild(t *testing.T) {
+	content := `
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Example EAPI 8 package"
+HOMEPAGE="https://example.com/"
+SRC_URI="https://example.com/${P}.tar.gz"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="ssl gnutls mysql postgres"
+
+RDEPEND="
+	>=sys-libs/zlib-1.2.13
+	ssl? ( dev-libs/openssl:0= )
+"
+DEPEND="${RDEPEND}"
+BDEPEND="sys-devel/gcc"
+IDEPEND="app-misc/pax-utils"
+PDEPEND="
+	mysql? ( dev-db/mysql-connector-c )
+	postgres? ( dev-db/postgresql )
+"
+
+REQUIRED_USE="^^ ( ssl gnutls )"
+PROPERTIES="live"
+RESTRICT="mirror test"
+`
+
+	parser := NewEbuildParser(content)
+
+	// Test IDEPEND
+	deps, err := parser.ParseDependencies()
+	if err != nil {
+		t.Fatalf("ParseDependencies() error: %v", err)
+	}
+
+	var hasIDEPEND, hasPDEPEND bool
+	for _, dep := range deps {
+		if dep.DepType == DepTypeInstall {
+			hasIDEPEND = true
+		}
+		if dep.DepType == DepTypePostMerge {
+			hasPDEPEND = true
+		}
+	}
+
+	if !hasIDEPEND {
+		t.Error("Expected to find IDEPEND dependencies")
+	}
+	if !hasPDEPEND {
+		t.Error("Expected to find PDEPEND dependencies")
+	}
+
+	// Test REQUIRED_USE
+	requiredUse := parser.ExtractRequiredUse()
+	if requiredUse != "^^ ( ssl gnutls )" {
+		t.Errorf("REQUIRED_USE = %q, expected %q", requiredUse, "^^ ( ssl gnutls )")
+	}
+
+	// Test PROPERTIES
+	props := parser.ExtractProperties()
+	if len(props) != 1 || props[0] != "live" {
+		t.Errorf("PROPERTIES = %v, expected [live]", props)
+	}
+
+	// Test RESTRICT
+	restrict := parser.ExtractRestrict()
+	if len(restrict) != 2 {
+		t.Errorf("RESTRICT = %v, expected [mirror test]", restrict)
+	}
+}
+
+// TestParseSpaceSeparatedList tests the helper function
+func TestParseSpaceSeparatedList(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"", nil},
+		{"   ", nil},
+		{"single", []string{"single"}},
+		{"one two", []string{"one", "two"}},
+		{"one  two   three", []string{"one", "two", "three"}},
+		{"\tone\ttwo\t", []string{"one", "two"}},
+		{"mixed\t space\nnewline", []string{"mixed", "space", "newline"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := parseSpaceSeparatedList(tt.input)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("parseSpaceSeparatedList(%q) = %v, expected %v", tt.input, result, tt.expected)
+				return
+			}
+
+			for i, expected := range tt.expected {
+				if result[i] != expected {
+					t.Errorf("parseSpaceSeparatedList(%q)[%d] = %q, expected %q", tt.input, i, result[i], expected)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkPropertiesParsing benchmarks PROPERTIES extraction
+func BenchmarkPropertiesParsing(b *testing.B) {
+	content := `
+PROPERTIES="interactive live test_network"
+RESTRICT="mirror fetch strip test"
+`
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		parser := NewEbuildParser(content)
+		_ = parser.ExtractProperties()
+		_ = parser.ExtractRestrict()
+	}
+}

--- a/internal/repo/mock_repo.go
+++ b/internal/repo/mock_repo.go
@@ -105,6 +105,23 @@ func (m *MockRepository) FindBySpecification(spec Specification) ([]*pkg.Package
 	return result, nil
 }
 
+// FindByAtom finds all packages matching a PMS-compliant atom.
+// Uses Atom.Matches() for version, slot, and subslot matching.
+func (m *MockRepository) FindByAtom(atom *pkg.Atom) ([]*pkg.Package, error) {
+	if atom == nil {
+		return nil, fmt.Errorf("atom is nil")
+	}
+
+	var result []*pkg.Package
+	for _, p := range m.packages {
+		if atom.Matches(p) {
+			copyPkg := *p
+			result = append(result, &copyPkg)
+		}
+	}
+	return result, nil
+}
+
 // GetAllVersions returns all versions of a package
 // Note: MockRepository stores only one version per package
 func (m *MockRepository) GetAllVersions(packageName string) ([]*pkg.Package, error) {

--- a/internal/repo/portage.go
+++ b/internal/repo/portage.go
@@ -328,3 +328,32 @@ func (pr *PortageRepository) Count() (int, error) {
 
 	return count, nil
 }
+
+// FindByAtom finds all packages matching a PMS-compliant atom.
+// Uses Atom.Matches() for version, slot, and subslot matching.
+// Optimized: only searches the specific category/package directory.
+func (pr *PortageRepository) FindByAtom(atom *pkg.Atom) ([]*pkg.Package, error) {
+	if atom == nil {
+		return nil, fmt.Errorf("atom is nil")
+	}
+
+	// Construct the package directory path from atom's category/package
+	packageName := atom.CP()
+
+	// Get all versions of this package
+	versions, err := pr.GetAllVersions(packageName)
+	if err != nil {
+		// Package doesn't exist - return empty slice, not error
+		return []*pkg.Package{}, nil
+	}
+
+	// Filter by atom matching (version, slot, subslot constraints)
+	var result []*pkg.Package
+	for _, p := range versions {
+		if atom.Matches(p) {
+			result = append(result, p)
+		}
+	}
+
+	return result, nil
+}

--- a/internal/repo/repository.go
+++ b/internal/repo/repository.go
@@ -16,6 +16,11 @@ type Repository interface {
 	// FindBySpecification finds all packages matching the specification
 	FindBySpecification(spec Specification) ([]*pkg.Package, error)
 
+	// FindByAtom finds all packages matching a PMS-compliant atom.
+	// Supports version constraints, slots, and USE flags.
+	// Example atoms: ">=sys-libs/glibc-2.38", "dev-lang/python:3.12"
+	FindByAtom(atom *pkg.Atom) ([]*pkg.Package, error)
+
 	// GetAllVersions returns all versions of a given package
 	GetAllVersions(packageName string) ([]*pkg.Package, error)
 

--- a/internal/repo/srcuri_parser.go
+++ b/internal/repo/srcuri_parser.go
@@ -1,0 +1,481 @@
+// Package repo provides repository abstractions for package management.
+//
+// This file implements SRC_URI parsing per PMS Section 7.2.9.
+// It handles arrow syntax for filename renaming and USE flag conditionals.
+package repo
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// SrcURIEntry represents a single source file entry from SRC_URI.
+//
+// SrcURIEntry is a Value Object - immutable after creation.
+// It contains all information needed to download a source file.
+type SrcURIEntry struct {
+	// URL is the download URL
+	URL string
+
+	// Filename is the local filename (from arrow syntax, or basename of URL)
+	Filename string
+
+	// UseFlag is the conditional USE flag (empty if unconditional)
+	// For "ssl? ( url )" this would be "ssl"
+	UseFlag string
+
+	// Negate is true for negated conditions (!useflag?)
+	// For "!minimal? ( url )" this would be true with UseFlag="minimal"
+	Negate bool
+}
+
+// SrcURIParser handles parsing of SRC_URI with arrow syntax and conditionals.
+//
+// The parser supports:
+//   - Arrow syntax: url -> filename
+//   - USE conditionals: use? ( ... )
+//   - Negated conditionals: !use? ( ... )
+//   - Nested conditionals
+//   - Variable expansion: ${P}, ${PV}, etc.
+type SrcURIParser struct {
+	// vars holds variable values for expansion (P, PV, PN, etc.)
+	vars map[string]string
+
+	// activeFlags indicates which USE flags are enabled
+	activeFlags map[string]bool
+}
+
+// NewSrcURIParser creates a new SRC_URI parser with variable mappings.
+//
+// The vars parameter should contain Portage variables like:
+//   - P: package-version (e.g., "hello-1.0")
+//   - PV: version (e.g., "1.0")
+//   - PN: package name (e.g., "hello")
+//
+// The activeFlags parameter indicates which USE flags are enabled.
+func NewSrcURIParser(vars map[string]string, activeFlags map[string]bool) *SrcURIParser {
+	p := &SrcURIParser{
+		vars:        make(map[string]string),
+		activeFlags: make(map[string]bool),
+	}
+
+	// Copy vars to avoid external modification
+	for k, v := range vars {
+		p.vars[k] = v
+	}
+
+	// Copy activeFlags
+	for k, v := range activeFlags {
+		p.activeFlags[k] = v
+	}
+
+	return p
+}
+
+// Parse parses SRC_URI content and returns entries for active USE flags.
+//
+// The parser handles:
+//   - Simple URLs: https://example.com/foo.tar.gz
+//   - Arrow syntax: https://example.com/foo.tar.gz -> bar.tar.gz
+//   - USE conditionals: ssl? ( https://example.com/ssl.tar.gz )
+//   - Negated conditionals: !minimal? ( https://example.com/extras.tar.gz )
+//   - Nested conditionals: ssl? ( gnutls? ( url1 ) openssl? ( url2 ) )
+//   - Variable expansion in filenames: -> ${P}.tar.gz
+func (p *SrcURIParser) Parse(srcURI string) ([]SrcURIEntry, error) {
+	tokens := tokenizeSrcURI(srcURI)
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+
+	entries, _, err := p.parseTokens(tokens, 0, "", false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing SRC_URI: %w", err)
+	}
+
+	return entries, nil
+}
+
+// parseTokens recursively parses tokens starting at index.
+// Returns entries, next index to process, and any error.
+func (p *SrcURIParser) parseTokens(tokens []string, start int, useFlag string, negate bool) ([]SrcURIEntry, int, error) {
+	var entries []SrcURIEntry
+	i := start
+
+	for i < len(tokens) {
+		token := tokens[i]
+
+		// Handle closing parenthesis - end of group
+		if token == ")" {
+			return entries, i + 1, nil
+		}
+
+		// Handle USE flag conditional: flag? or !flag?
+		if isUseCondition(token) {
+			flag, neg := parseUseCondition(token)
+
+			// Next token must be "("
+			if i+1 >= len(tokens) || tokens[i+1] != "(" {
+				return nil, i, fmt.Errorf("expected '(' after %s at position %d", token, i)
+			}
+
+			// Parse the conditional block
+			blockEntries, nextIdx, err := p.parseTokens(tokens, i+2, flag, neg)
+			if err != nil {
+				return nil, i, err
+			}
+
+			// Only include entries if condition is met
+			if p.conditionMet(flag, neg) {
+				entries = append(entries, blockEntries...)
+			}
+
+			i = nextIdx
+			continue
+		}
+
+		// Handle opening parenthesis - anonymous group
+		if token == "(" {
+			groupEntries, nextIdx, err := p.parseTokens(tokens, i+1, useFlag, negate)
+			if err != nil {
+				return nil, i, err
+			}
+			entries = append(entries, groupEntries...)
+			i = nextIdx
+			continue
+		}
+
+		// Handle URL
+		if isURL(token) {
+			entry, advance := p.parseURLEntry(tokens, i, useFlag, negate)
+			entries = append(entries, entry)
+			i += advance
+			continue
+		}
+
+		// Skip unknown tokens
+		i++
+	}
+
+	return entries, i, nil
+}
+
+// parseURLEntry parses a URL entry, handling optional arrow syntax.
+// Returns the entry and number of tokens consumed.
+func (p *SrcURIParser) parseURLEntry(tokens []string, i int, useFlag string, negate bool) (SrcURIEntry, int) {
+	entry := SrcURIEntry{
+		URL:     tokens[i],
+		UseFlag: useFlag,
+		Negate:  negate,
+	}
+
+	// Check for arrow syntax: URL -> filename
+	if i+2 < len(tokens) && tokens[i+1] == "->" {
+		// Expand variables in the filename
+		entry.Filename = p.expandVariables(tokens[i+2])
+		return entry, 3 // consumed: URL, ->, filename
+	}
+
+	// No arrow - use basename of URL
+	entry.Filename = extractFilename(entry.URL)
+	return entry, 1 // consumed: URL only
+}
+
+// conditionMet checks if a USE flag condition is satisfied.
+func (p *SrcURIParser) conditionMet(flag string, negate bool) bool {
+	active := p.activeFlags[flag]
+	if negate {
+		return !active
+	}
+	return active
+}
+
+// expandVariables expands ${VAR} references in a string.
+//
+// Supports:
+//   - ${VAR} -> value of VAR (empty string if not set)
+//   - ${VAR:-default} -> value of VAR, or "default" if unset
+func (p *SrcURIParser) expandVariables(s string) string {
+	result := s
+
+	// Simple variable expansion: ${VAR}
+	for k, v := range p.vars {
+		result = strings.ReplaceAll(result, "${"+k+"}", v)
+	}
+
+	// Handle ${VAR:-default} pattern and remove unexpanded variables
+	result = expandDefaultSyntax(result, p.vars)
+
+	// Remove any remaining unexpanded ${VAR} patterns (undefined variables)
+	result = removeUnexpandedVariables(result)
+
+	return result
+}
+
+// removeUnexpandedVariables removes any remaining ${VAR} patterns.
+// This handles undefined variables by removing them entirely.
+func removeUnexpandedVariables(s string) string {
+	result := s
+
+	for {
+		// Find ${
+		idx := strings.Index(result, "${")
+		if idx == -1 {
+			break
+		}
+
+		// Find matching }
+		endIdx := strings.Index(result[idx:], "}")
+		if endIdx == -1 {
+			break
+		}
+		endIdx += idx
+
+		// Remove the entire ${...} pattern
+		result = result[:idx] + result[endIdx+1:]
+	}
+
+	return result
+}
+
+// expandDefaultSyntax handles ${VAR:-default} patterns.
+func expandDefaultSyntax(s string, vars map[string]string) string {
+	result := s
+	start := 0
+
+	for {
+		// Find ${
+		idx := strings.Index(result[start:], "${")
+		if idx == -1 {
+			break
+		}
+		idx += start
+
+		// Find matching }
+		endIdx := strings.Index(result[idx:], "}")
+		if endIdx == -1 {
+			break
+		}
+		endIdx += idx
+
+		// Extract content: VAR:-default
+		content := result[idx+2 : endIdx]
+
+		// Check for :- syntax
+		if colonIdx := strings.Index(content, ":-"); colonIdx != -1 {
+			varName := content[:colonIdx]
+			defaultVal := content[colonIdx+2:]
+
+			var replacement string
+			if val, ok := vars[varName]; ok && val != "" {
+				replacement = val
+			} else {
+				replacement = defaultVal
+			}
+
+			result = result[:idx] + replacement + result[endIdx+1:]
+			// Don't advance start - the replacement might contain more variables
+			continue
+		}
+
+		// Move past this ${} block
+		start = endIdx + 1
+	}
+
+	return result
+}
+
+// tokenizeSrcURI splits SRC_URI content into tokens.
+//
+// Tokens are:
+//   - URLs (starting with http://, https://, ftp://, mirror://)
+//   - USE conditions (ending with ?)
+//   - Arrow operator (->)
+//   - Parentheses ( )
+//   - Filenames (after ->)
+func tokenizeSrcURI(srcURI string) []string {
+	var tokens []string
+	var current strings.Builder
+
+	// Normalize whitespace
+	content := strings.TrimSpace(srcURI)
+	if content == "" {
+		return nil
+	}
+
+	flushCurrent := func() {
+		if current.Len() > 0 {
+			tokens = append(tokens, current.String())
+			current.Reset()
+		}
+	}
+
+	i := 0
+	for i < len(content) {
+		ch := content[i]
+
+		switch ch {
+		case '(':
+			flushCurrent()
+			tokens = append(tokens, "(")
+			i++
+
+		case ')':
+			flushCurrent()
+			tokens = append(tokens, ")")
+			i++
+
+		case ' ', '\t', '\n', '\r':
+			flushCurrent()
+			// Skip consecutive whitespace
+			for i < len(content) && isWhitespace(content[i]) {
+				i++
+			}
+
+		case '-':
+			// Check for arrow operator
+			if i+1 < len(content) && content[i+1] == '>' {
+				flushCurrent()
+				tokens = append(tokens, "->")
+				i += 2
+			} else {
+				current.WriteByte(ch)
+				i++
+			}
+
+		default:
+			current.WriteByte(ch)
+			i++
+		}
+	}
+
+	flushCurrent()
+	return tokens
+}
+
+// isWhitespace checks if a byte is whitespace.
+func isWhitespace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
+}
+
+// isUseCondition checks if a token is a USE flag condition.
+// Matches: flag? or !flag?
+func isUseCondition(token string) bool {
+	if !strings.HasSuffix(token, "?") {
+		return false
+	}
+
+	// Remove the ? and optional ! prefix
+	flag := strings.TrimSuffix(token, "?")
+	flag = strings.TrimPrefix(flag, "!")
+
+	// Must have a valid flag name remaining
+	return len(flag) > 0 && isValidUseFlagName(flag)
+}
+
+// isValidUseFlagName checks if a string is a valid USE flag name.
+// USE flag names: [A-Za-z0-9][A-Za-z0-9+_@-]*
+func isValidUseFlagName(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+
+	// First character must be alphanumeric
+	first := name[0]
+	if !isAlphaNum(first) {
+		return false
+	}
+
+	// Rest can include +, _, @, -
+	for i := 1; i < len(name); i++ {
+		ch := name[i]
+		if !isAlphaNum(ch) && ch != '+' && ch != '_' && ch != '@' && ch != '-' {
+			return false
+		}
+	}
+
+	return true
+}
+
+// isAlphaNum checks if a byte is alphanumeric.
+func isAlphaNum(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')
+}
+
+// parseUseCondition extracts the USE flag name and negation from a condition.
+// Input: "flag?" returns ("flag", false)
+// Input: "!flag?" returns ("flag", true)
+func parseUseCondition(token string) (flag string, negate bool) {
+	// Remove trailing ?
+	flag = strings.TrimSuffix(token, "?")
+
+	// Check for negation
+	if strings.HasPrefix(flag, "!") {
+		negate = true
+		flag = strings.TrimPrefix(flag, "!")
+	}
+
+	return flag, negate
+}
+
+// isURL checks if a token looks like a URL.
+func isURL(token string) bool {
+	// Check for common URL schemes
+	schemes := []string{
+		"http://",
+		"https://",
+		"ftp://",
+		"mirror://",
+	}
+
+	lower := strings.ToLower(token)
+	for _, scheme := range schemes {
+		if strings.HasPrefix(lower, scheme) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// extractFilename extracts the filename from a URL.
+//
+// For most URLs, this is the basename.
+// Special handling for mirror:// URLs and query strings.
+func extractFilename(url string) string {
+	// Handle mirror:// URLs: mirror://sourceforge/project/file.tar.gz
+	if strings.HasPrefix(strings.ToLower(url), "mirror://") {
+		// Extract path after mirror://name/
+		parts := strings.SplitN(url, "/", 4) // mirror:, empty, name, path
+		if len(parts) >= 4 {
+			return path.Base(parts[3])
+		}
+	}
+
+	// Remove query string and fragment
+	clean := url
+	if idx := strings.Index(clean, "?"); idx != -1 {
+		clean = clean[:idx]
+	}
+	if idx := strings.Index(clean, "#"); idx != -1 {
+		clean = clean[:idx]
+	}
+
+	return path.Base(clean)
+}
+
+// ParseSrcURI is a convenience function for parsing SRC_URI.
+//
+// It creates a parser with the given variables and flags, then parses the content.
+func ParseSrcURI(content string, activeFlags map[string]bool, vars map[string]string) ([]SrcURIEntry, error) {
+	parser := NewSrcURIParser(vars, activeFlags)
+	return parser.Parse(content)
+}
+
+// ExpandFilename expands variables in a filename string.
+//
+// This is a convenience function for expanding filenames outside of parsing.
+func ExpandFilename(filename string, vars map[string]string) string {
+	parser := NewSrcURIParser(vars, nil)
+	return parser.expandVariables(filename)
+}

--- a/internal/repo/srcuri_parser_test.go
+++ b/internal/repo/srcuri_parser_test.go
@@ -1,0 +1,857 @@
+package repo
+
+import (
+	"testing"
+)
+
+func TestParseSrcURI_SimpleURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantLen  int
+		wantURL  string
+		wantFile string
+	}{
+		{
+			name:     "simple https URL",
+			input:    "https://example.com/foo-1.0.tar.gz",
+			wantLen:  1,
+			wantURL:  "https://example.com/foo-1.0.tar.gz",
+			wantFile: "foo-1.0.tar.gz",
+		},
+		{
+			name:     "simple http URL",
+			input:    "http://example.com/bar.tar.bz2",
+			wantLen:  1,
+			wantURL:  "http://example.com/bar.tar.bz2",
+			wantFile: "bar.tar.bz2",
+		},
+		{
+			name:     "ftp URL",
+			input:    "ftp://ftp.example.com/pub/file.tar.xz",
+			wantLen:  1,
+			wantURL:  "ftp://ftp.example.com/pub/file.tar.xz",
+			wantFile: "file.tar.xz",
+		},
+		{
+			name:     "mirror URL",
+			input:    "mirror://sourceforge/project/file.tar.gz",
+			wantLen:  1,
+			wantURL:  "mirror://sourceforge/project/file.tar.gz",
+			wantFile: "file.tar.gz",
+		},
+		{
+			name:     "multiple URLs",
+			input:    "https://example.com/a.tar.gz https://example.com/b.tar.gz",
+			wantLen:  2,
+			wantURL:  "https://example.com/a.tar.gz",
+			wantFile: "a.tar.gz",
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			wantLen: 0,
+		},
+		{
+			name:    "whitespace only",
+			input:   "   \t\n  ",
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			entries, err := ParseSrcURI(tt.input, nil, nil)
+			if err != nil {
+				t.Fatalf("ParseSrcURI() error = %v", err)
+			}
+
+			if len(entries) != tt.wantLen {
+				t.Fatalf("got %d entries, want %d", len(entries), tt.wantLen)
+			}
+
+			if tt.wantLen > 0 {
+				if entries[0].URL != tt.wantURL {
+					t.Errorf("URL = %q, want %q", entries[0].URL, tt.wantURL)
+				}
+				if entries[0].Filename != tt.wantFile {
+					t.Errorf("Filename = %q, want %q", entries[0].Filename, tt.wantFile)
+				}
+			}
+		})
+	}
+}
+
+func TestParseSrcURI_ArrowSyntax(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantURL  string
+		wantFile string
+	}{
+		{
+			name:     "simple arrow",
+			input:    "https://example.com/foo.tar.gz -> bar.tar.gz",
+			wantURL:  "https://example.com/foo.tar.gz",
+			wantFile: "bar.tar.gz",
+		},
+		{
+			name:     "github archive rename",
+			input:    "https://github.com/user/repo/archive/v1.0.tar.gz -> myproject-1.0.tar.gz",
+			wantURL:  "https://github.com/user/repo/archive/v1.0.tar.gz",
+			wantFile: "myproject-1.0.tar.gz",
+		},
+		{
+			name:     "arrow with path basename",
+			input:    "https://downloads.example.com/releases/v1.2.3/latest.tar.gz -> specific-1.2.3.tar.gz",
+			wantURL:  "https://downloads.example.com/releases/v1.2.3/latest.tar.gz",
+			wantFile: "specific-1.2.3.tar.gz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			entries, err := ParseSrcURI(tt.input, nil, nil)
+			if err != nil {
+				t.Fatalf("ParseSrcURI() error = %v", err)
+			}
+
+			if len(entries) != 1 {
+				t.Fatalf("got %d entries, want 1", len(entries))
+			}
+
+			if entries[0].URL != tt.wantURL {
+				t.Errorf("URL = %q, want %q", entries[0].URL, tt.wantURL)
+			}
+			if entries[0].Filename != tt.wantFile {
+				t.Errorf("Filename = %q, want %q", entries[0].Filename, tt.wantFile)
+			}
+		})
+	}
+}
+
+func TestParseSrcURI_VariableExpansion(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]string{
+		"P":  "hello-1.0",
+		"PV": "1.0",
+		"PN": "hello",
+		"PF": "hello-1.0-r0",
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		vars     map[string]string
+		wantFile string
+	}{
+		{
+			name:     "expand P in filename",
+			input:    "https://example.com/v1.0.tar.gz -> ${P}.tar.gz",
+			vars:     vars,
+			wantFile: "hello-1.0.tar.gz",
+		},
+		{
+			name:     "expand PV in filename",
+			input:    "https://example.com/archive.tar.gz -> myapp-${PV}.tar.gz",
+			vars:     vars,
+			wantFile: "myapp-1.0.tar.gz",
+		},
+		{
+			name:     "expand PN in filename",
+			input:    "https://example.com/src.tar.gz -> ${PN}-src.tar.gz",
+			vars:     vars,
+			wantFile: "hello-src.tar.gz",
+		},
+		{
+			name:     "multiple variables",
+			input:    "https://example.com/src.tar.gz -> ${PN}-${PV}-src.tar.gz",
+			vars:     vars,
+			wantFile: "hello-1.0-src.tar.gz",
+		},
+		{
+			name:     "no expansion without vars",
+			input:    "https://example.com/src.tar.gz -> ${P}.tar.gz",
+			vars:     nil,
+			wantFile: ".tar.gz", // Variable removed, leaving just extension
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			entries, err := ParseSrcURI(tt.input, nil, tt.vars)
+			if err != nil {
+				t.Fatalf("ParseSrcURI() error = %v", err)
+			}
+
+			if len(entries) != 1 {
+				t.Fatalf("got %d entries, want 1", len(entries))
+			}
+
+			if entries[0].Filename != tt.wantFile {
+				t.Errorf("Filename = %q, want %q", entries[0].Filename, tt.wantFile)
+			}
+		})
+	}
+}
+
+func TestParseSrcURI_Conditionals(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		flags   map[string]bool
+		wantLen int
+		wantURL string
+	}{
+		{
+			name:    "enabled flag includes URL",
+			input:   "doc? ( https://example.com/doc.pdf )",
+			flags:   map[string]bool{"doc": true},
+			wantLen: 1,
+			wantURL: "https://example.com/doc.pdf",
+		},
+		{
+			name:    "disabled flag excludes URL",
+			input:   "doc? ( https://example.com/doc.pdf )",
+			flags:   map[string]bool{"doc": false},
+			wantLen: 0,
+		},
+		{
+			name:    "missing flag excludes URL",
+			input:   "doc? ( https://example.com/doc.pdf )",
+			flags:   map[string]bool{},
+			wantLen: 0,
+		},
+		{
+			name:    "negated flag - disabled includes URL",
+			input:   "!minimal? ( https://example.com/extras.tar.gz )",
+			flags:   map[string]bool{"minimal": false},
+			wantLen: 1,
+			wantURL: "https://example.com/extras.tar.gz",
+		},
+		{
+			name:    "negated flag - enabled excludes URL",
+			input:   "!minimal? ( https://example.com/extras.tar.gz )",
+			flags:   map[string]bool{"minimal": true},
+			wantLen: 0,
+		},
+		{
+			name:    "negated flag - missing includes URL",
+			input:   "!minimal? ( https://example.com/extras.tar.gz )",
+			flags:   map[string]bool{},
+			wantLen: 1,
+			wantURL: "https://example.com/extras.tar.gz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			entries, err := ParseSrcURI(tt.input, tt.flags, nil)
+			if err != nil {
+				t.Fatalf("ParseSrcURI() error = %v", err)
+			}
+
+			if len(entries) != tt.wantLen {
+				t.Fatalf("got %d entries, want %d", len(entries), tt.wantLen)
+			}
+
+			if tt.wantLen > 0 && entries[0].URL != tt.wantURL {
+				t.Errorf("URL = %q, want %q", entries[0].URL, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestParseSrcURI_ConditionalMetadata(t *testing.T) {
+	t.Parallel()
+
+	input := "ssl? ( https://example.com/ssl.tar.gz )"
+	flags := map[string]bool{"ssl": true}
+
+	entries, err := ParseSrcURI(input, flags, nil)
+	if err != nil {
+		t.Fatalf("ParseSrcURI() error = %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+
+	entry := entries[0]
+	if entry.UseFlag != "ssl" {
+		t.Errorf("UseFlag = %q, want %q", entry.UseFlag, "ssl")
+	}
+	if entry.Negate {
+		t.Error("Negate = true, want false")
+	}
+}
+
+func TestParseSrcURI_NegatedConditionalMetadata(t *testing.T) {
+	t.Parallel()
+
+	input := "!minimal? ( https://example.com/extras.tar.gz )"
+	flags := map[string]bool{"minimal": false}
+
+	entries, err := ParseSrcURI(input, flags, nil)
+	if err != nil {
+		t.Fatalf("ParseSrcURI() error = %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+
+	entry := entries[0]
+	if entry.UseFlag != "minimal" {
+		t.Errorf("UseFlag = %q, want %q", entry.UseFlag, "minimal")
+	}
+	if !entry.Negate {
+		t.Error("Negate = false, want true")
+	}
+}
+
+func TestParseSrcURI_NestedConditionals(t *testing.T) {
+	t.Parallel()
+
+	input := `
+		ssl? (
+			gnutls? ( https://example.com/gnutls.tar.gz )
+			openssl? ( https://example.com/openssl.tar.gz )
+		)
+	`
+
+	tests := []struct {
+		name    string
+		flags   map[string]bool
+		wantLen int
+		wantURL string
+	}{
+		{
+			name:    "ssl and gnutls enabled",
+			flags:   map[string]bool{"ssl": true, "gnutls": true, "openssl": false},
+			wantLen: 1,
+			wantURL: "https://example.com/gnutls.tar.gz",
+		},
+		{
+			name:    "ssl and openssl enabled",
+			flags:   map[string]bool{"ssl": true, "gnutls": false, "openssl": true},
+			wantLen: 1,
+			wantURL: "https://example.com/openssl.tar.gz",
+		},
+		{
+			name:    "ssl enabled, both backends",
+			flags:   map[string]bool{"ssl": true, "gnutls": true, "openssl": true},
+			wantLen: 2,
+		},
+		{
+			name:    "ssl disabled",
+			flags:   map[string]bool{"ssl": false, "gnutls": true, "openssl": true},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			entries, err := ParseSrcURI(input, tt.flags, nil)
+			if err != nil {
+				t.Fatalf("ParseSrcURI() error = %v", err)
+			}
+
+			if len(entries) != tt.wantLen {
+				t.Fatalf("got %d entries, want %d", len(entries), tt.wantLen)
+			}
+
+			if tt.wantLen == 1 && entries[0].URL != tt.wantURL {
+				t.Errorf("URL = %q, want %q", entries[0].URL, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestParseSrcURI_ConditionalWithArrow(t *testing.T) {
+	t.Parallel()
+
+	input := "ssl? ( https://example.com/ssl-support.tar.gz -> ${P}-ssl.tar.gz )"
+	flags := map[string]bool{"ssl": true}
+	vars := map[string]string{"P": "myapp-1.0"}
+
+	entries, err := ParseSrcURI(input, flags, vars)
+	if err != nil {
+		t.Fatalf("ParseSrcURI() error = %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+
+	entry := entries[0]
+	if entry.URL != "https://example.com/ssl-support.tar.gz" {
+		t.Errorf("URL = %q, want %q", entry.URL, "https://example.com/ssl-support.tar.gz")
+	}
+	if entry.Filename != "myapp-1.0-ssl.tar.gz" {
+		t.Errorf("Filename = %q, want %q", entry.Filename, "myapp-1.0-ssl.tar.gz")
+	}
+}
+
+func TestParseSrcURI_MixedContent(t *testing.T) {
+	t.Parallel()
+
+	// Real-world style SRC_URI
+	input := `
+		https://example.com/main-1.0.tar.gz
+		doc? ( https://example.com/manual.pdf -> ${PN}-manual.pdf )
+		!minimal? ( https://example.com/extras.tar.gz )
+		test? (
+			https://example.com/test-data.tar.gz
+			https://example.com/test-scripts.tar.gz -> test-scripts-1.0.tar.gz
+		)
+	`
+
+	vars := map[string]string{"PN": "myapp", "P": "myapp-1.0", "PV": "1.0"}
+	flags := map[string]bool{
+		"doc":     true,
+		"minimal": false,
+		"test":    true,
+	}
+
+	entries, err := ParseSrcURI(input, flags, vars)
+	if err != nil {
+		t.Fatalf("ParseSrcURI() error = %v", err)
+	}
+
+	// Expected: main.tar.gz + manual.pdf + extras.tar.gz + test-data.tar.gz + test-scripts.tar.gz
+	if len(entries) != 5 {
+		t.Fatalf("got %d entries, want 5", len(entries))
+	}
+
+	// Check specific entries
+	expectedFiles := map[string]bool{
+		"main-1.0.tar.gz":         true,
+		"myapp-manual.pdf":        true,
+		"extras.tar.gz":           true,
+		"test-data.tar.gz":        true,
+		"test-scripts-1.0.tar.gz": true,
+	}
+
+	for _, entry := range entries {
+		if !expectedFiles[entry.Filename] {
+			t.Errorf("unexpected filename: %q", entry.Filename)
+		}
+		delete(expectedFiles, entry.Filename)
+	}
+
+	if len(expectedFiles) > 0 {
+		for f := range expectedFiles {
+			t.Errorf("missing expected filename: %q", f)
+		}
+	}
+}
+
+func TestParseSrcURI_URLWithQueryString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantFile string
+	}{
+		{
+			name:     "URL with query string",
+			input:    "https://example.com/download.php?file=foo.tar.gz",
+			wantFile: "download.php",
+		},
+		{
+			name:     "URL with fragment",
+			input:    "https://example.com/file.tar.gz#section",
+			wantFile: "file.tar.gz",
+		},
+		{
+			name:     "arrow overrides query string",
+			input:    "https://example.com/download.php?file=foo -> actual-file.tar.gz",
+			wantFile: "actual-file.tar.gz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			entries, err := ParseSrcURI(tt.input, nil, nil)
+			if err != nil {
+				t.Fatalf("ParseSrcURI() error = %v", err)
+			}
+
+			if len(entries) != 1 {
+				t.Fatalf("got %d entries, want 1", len(entries))
+			}
+
+			if entries[0].Filename != tt.wantFile {
+				t.Errorf("Filename = %q, want %q", entries[0].Filename, tt.wantFile)
+			}
+		})
+	}
+}
+
+func TestParseSrcURI_MirrorURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantFile string
+	}{
+		{
+			name:     "sourceforge mirror",
+			input:    "mirror://sourceforge/project/file.tar.gz",
+			wantFile: "file.tar.gz",
+		},
+		{
+			name:     "gnu mirror",
+			input:    "mirror://gnu/hello/hello-2.10.tar.gz",
+			wantFile: "hello-2.10.tar.gz",
+		},
+		{
+			name:     "mirror with arrow",
+			input:    "mirror://sourceforge/proj/src.tar.gz -> custom-name.tar.gz",
+			wantFile: "custom-name.tar.gz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			entries, err := ParseSrcURI(tt.input, nil, nil)
+			if err != nil {
+				t.Fatalf("ParseSrcURI() error = %v", err)
+			}
+
+			if len(entries) != 1 {
+				t.Fatalf("got %d entries, want 1", len(entries))
+			}
+
+			if entries[0].Filename != tt.wantFile {
+				t.Errorf("Filename = %q, want %q", entries[0].Filename, tt.wantFile)
+			}
+		})
+	}
+}
+
+func TestTokenizeSrcURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		expect []string
+	}{
+		{
+			name:   "simple URL",
+			input:  "https://example.com/file.tar.gz",
+			expect: []string{"https://example.com/file.tar.gz"},
+		},
+		{
+			name:   "arrow syntax",
+			input:  "https://example.com/file.tar.gz -> renamed.tar.gz",
+			expect: []string{"https://example.com/file.tar.gz", "->", "renamed.tar.gz"},
+		},
+		{
+			name:   "conditional",
+			input:  "ssl? ( https://example.com/ssl.tar.gz )",
+			expect: []string{"ssl?", "(", "https://example.com/ssl.tar.gz", ")"},
+		},
+		{
+			name:   "negated conditional",
+			input:  "!minimal? ( https://example.com/extras.tar.gz )",
+			expect: []string{"!minimal?", "(", "https://example.com/extras.tar.gz", ")"},
+		},
+		{
+			name:   "multiline",
+			input:  "https://a.com/a.tar.gz\nhttps://b.com/b.tar.gz",
+			expect: []string{"https://a.com/a.tar.gz", "https://b.com/b.tar.gz"},
+		},
+		{
+			name:   "tabs and spaces",
+			input:  "https://a.com/a.tar.gz \t https://b.com/b.tar.gz",
+			expect: []string{"https://a.com/a.tar.gz", "https://b.com/b.tar.gz"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tokens := tokenizeSrcURI(tt.input)
+
+			if len(tokens) != len(tt.expect) {
+				t.Fatalf("got %d tokens %v, want %d %v", len(tokens), tokens, len(tt.expect), tt.expect)
+			}
+
+			for i, tok := range tokens {
+				if tok != tt.expect[i] {
+					t.Errorf("token[%d] = %q, want %q", i, tok, tt.expect[i])
+				}
+			}
+		})
+	}
+}
+
+func TestIsUseCondition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"ssl?", true},
+		{"!ssl?", true},
+		{"doc?", true},
+		{"!minimal?", true},
+		{"ssl", false},
+		{"?", false},
+		{"!?", false},
+		{"->", false},
+		{"(", false},
+		{")", false},
+		{"https://example.com?query=1", false},
+		{"USE_EXPAND_HIDDEN?", true},
+		{"flag-with-dash?", true},
+		{"flag_with_underscore?", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			got := isUseCondition(tt.input)
+			if got != tt.want {
+				t.Errorf("isUseCondition(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseUseCondition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input      string
+		wantFlag   string
+		wantNegate bool
+	}{
+		{"ssl?", "ssl", false},
+		{"!ssl?", "ssl", true},
+		{"doc?", "doc", false},
+		{"!minimal?", "minimal", true},
+		{"USE_EXPAND?", "USE_EXPAND", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			flag, negate := parseUseCondition(tt.input)
+			if flag != tt.wantFlag {
+				t.Errorf("flag = %q, want %q", flag, tt.wantFlag)
+			}
+			if negate != tt.wantNegate {
+				t.Errorf("negate = %v, want %v", negate, tt.wantNegate)
+			}
+		})
+	}
+}
+
+func TestExpandFilename(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]string{
+		"P":  "hello-1.0",
+		"PV": "1.0",
+		"PN": "hello",
+	}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"${P}.tar.gz", "hello-1.0.tar.gz"},
+		{"${PN}-${PV}.tar.gz", "hello-1.0.tar.gz"},
+		{"no-vars.tar.gz", "no-vars.tar.gz"},
+		{"${UNKNOWN}.tar.gz", ".tar.gz"},
+		{"prefix-${P}-suffix.tar.gz", "prefix-hello-1.0-suffix.tar.gz"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			got := ExpandFilename(tt.input, vars)
+			if got != tt.want {
+				t.Errorf("ExpandFilename(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractFilename(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		url      string
+		wantFile string
+	}{
+		{"https://example.com/file.tar.gz", "file.tar.gz"},
+		{"https://example.com/path/to/file.tar.gz", "file.tar.gz"},
+		{"https://example.com/file.tar.gz?query=1", "file.tar.gz"},
+		{"https://example.com/file.tar.gz#section", "file.tar.gz"},
+		{"mirror://sourceforge/proj/file.tar.gz", "file.tar.gz"},
+		{"mirror://gnu/hello/hello-2.10.tar.gz", "hello-2.10.tar.gz"},
+		{"ftp://ftp.example.com/pub/file.tar.xz", "file.tar.xz"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			t.Parallel()
+
+			got := extractFilename(tt.url)
+			if got != tt.wantFile {
+				t.Errorf("extractFilename(%q) = %q, want %q", tt.url, got, tt.wantFile)
+			}
+		})
+	}
+}
+
+func TestIsURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"https://example.com/file.tar.gz", true},
+		{"http://example.com/file.tar.gz", true},
+		{"ftp://ftp.example.com/file.tar.gz", true},
+		{"mirror://sourceforge/proj/file.tar.gz", true},
+		{"HTTPS://EXAMPLE.COM/FILE.TAR.GZ", true},
+		{"file.tar.gz", false},
+		{"ssl?", false},
+		{"->", false},
+		{"(", false},
+		{")", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			got := isURL(tt.input)
+			if got != tt.want {
+				t.Errorf("isURL(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandDefaultSyntax(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]string{
+		"P":  "hello-1.0",
+		"PV": "1.0",
+	}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"${P:-unknown}.tar.gz", "hello-1.0.tar.gz"},
+		{"${MISSING:-default}.tar.gz", "default.tar.gz"},
+		{"${MISSING:-}.tar.gz", ".tar.gz"},
+		{"no-default.tar.gz", "no-default.tar.gz"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
+			got := expandDefaultSyntax(tt.input, vars)
+			if got != tt.want {
+				t.Errorf("expandDefaultSyntax(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSrcURIParser_NewParser(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]string{"P": "test-1.0"}
+	flags := map[string]bool{"ssl": true}
+
+	parser := NewSrcURIParser(vars, flags)
+
+	// Verify vars are copied (not shared)
+	vars["P"] = "modified"
+	if parser.vars["P"] != "test-1.0" {
+		t.Error("parser vars should be a copy, not shared reference")
+	}
+
+	// Verify flags are copied
+	flags["ssl"] = false
+	if !parser.activeFlags["ssl"] {
+		t.Error("parser flags should be a copy, not shared reference")
+	}
+}
+
+// Benchmark tests
+func BenchmarkParseSrcURI_Simple(b *testing.B) {
+	input := "https://example.com/file.tar.gz"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseSrcURI(input, nil, nil)
+	}
+}
+
+func BenchmarkParseSrcURI_Complex(b *testing.B) {
+	input := `
+		https://example.com/main-1.0.tar.gz
+		doc? ( https://example.com/manual.pdf -> ${PN}-manual.pdf )
+		!minimal? ( https://example.com/extras.tar.gz )
+		test? (
+			https://example.com/test-data.tar.gz
+			https://example.com/test-scripts.tar.gz -> test-scripts-1.0.tar.gz
+		)
+	`
+	vars := map[string]string{"PN": "myapp", "P": "myapp-1.0", "PV": "1.0"}
+	flags := map[string]bool{"doc": true, "minimal": false, "test": true}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = ParseSrcURI(input, flags, vars)
+	}
+}
+
+func BenchmarkTokenizeSrcURI(b *testing.B) {
+	input := "ssl? ( https://example.com/ssl.tar.gz -> ${P}-ssl.tar.gz )"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tokenizeSrcURI(input)
+	}
+}

--- a/internal/solver/atom_constraint_test.go
+++ b/internal/solver/atom_constraint_test.go
@@ -1,0 +1,229 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/grpmsoft/grpm/internal/pkg"
+)
+
+// TestGophersatAdapter_AddAtomConstraint tests adding constraints from Atom objects
+func TestGophersatAdapter_AddAtomConstraint(t *testing.T) {
+	adapter := NewGophersatAdapter()
+
+	// Register some packages
+	pkgZlib12 := pkg.NewPackage("sys-libs/zlib", "1.2.12", "0")
+	pkgZlib13 := pkg.NewPackage("sys-libs/zlib", "1.2.13", "0")
+	pkgZlib14 := pkg.NewPackage("sys-libs/zlib", "1.2.14", "0")
+
+	adapter.AddPackage(pkgZlib12)
+	adapter.AddPackage(pkgZlib13)
+	adapter.AddPackage(pkgZlib14)
+
+	tests := []struct {
+		name          string
+		atomStr       string
+		wantErr       bool
+		expectClauses int // number of clauses after adding
+	}{
+		{
+			name:          "any version",
+			atomStr:       "sys-libs/zlib",
+			expectClauses: 1, // one clause with all 3 versions
+		},
+		{
+			name:          "greater-equal constraint",
+			atomStr:       ">=sys-libs/zlib-1.2.13",
+			expectClauses: 1, // one clause with 2 versions (1.2.13 and 1.2.14)
+		},
+		{
+			name:          "exact version",
+			atomStr:       "=sys-libs/zlib-1.2.13",
+			expectClauses: 1, // one clause with 1 version (1.2.13)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fresh adapter for each test
+			testAdapter := NewGophersatAdapter()
+			testAdapter.AddPackage(pkgZlib12)
+			testAdapter.AddPackage(pkgZlib13)
+			testAdapter.AddPackage(pkgZlib14)
+
+			atom, err := pkg.ParseAtom(tt.atomStr)
+			if err != nil {
+				t.Fatalf("ParseAtom(%q) error: %v", tt.atomStr, err)
+			}
+
+			err = testAdapter.AddAtomConstraint(atom)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AddAtomConstraint() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if len(testAdapter.clauses) != tt.expectClauses {
+				t.Errorf("AddAtomConstraint() resulted in %d clauses, want %d",
+					len(testAdapter.clauses), tt.expectClauses)
+			}
+		})
+	}
+}
+
+// TestGophersatAdapter_AddAtomConstraint_Nil tests nil atom handling
+func TestGophersatAdapter_AddAtomConstraint_Nil(t *testing.T) {
+	adapter := NewGophersatAdapter()
+	err := adapter.AddAtomConstraint(nil)
+	if err == nil {
+		t.Error("AddAtomConstraint(nil) should return error")
+	}
+}
+
+// TestGophersatAdapter_AddAtomConstraint_NoMatch tests constraint with no matching packages
+func TestGophersatAdapter_AddAtomConstraint_NoMatch(t *testing.T) {
+	adapter := NewGophersatAdapter()
+
+	// Register a package
+	pkgZlib := pkg.NewPackage("sys-libs/zlib", "1.2.13", "0")
+	adapter.AddPackage(pkgZlib)
+
+	// Try to add constraint for non-existent package
+	atom, err := pkg.ParseAtom("dev-libs/openssl")
+	if err != nil {
+		t.Fatalf("ParseAtom error: %v", err)
+	}
+
+	// Should not error, just log warning
+	err = adapter.AddAtomConstraint(atom)
+	if err != nil {
+		t.Errorf("AddAtomConstraint() unexpected error: %v", err)
+	}
+
+	// No clauses should be added
+	if len(adapter.clauses) != 0 {
+		t.Errorf("Expected 0 clauses, got %d", len(adapter.clauses))
+	}
+}
+
+// TestGophersatAdapter_AddAtomConstraint_Slot tests slot constraint matching
+func TestGophersatAdapter_AddAtomConstraint_Slot(t *testing.T) {
+	adapter := NewGophersatAdapter()
+
+	// Register packages with different slots
+	pkgPython311 := pkg.NewPackage("dev-lang/python", "3.11.7", "3.11")
+	pkgPython312 := pkg.NewPackage("dev-lang/python", "3.12.1", "3.12")
+	pkgPython313 := pkg.NewPackage("dev-lang/python", "3.13.0", "3.13")
+
+	adapter.AddPackage(pkgPython311)
+	adapter.AddPackage(pkgPython312)
+	adapter.AddPackage(pkgPython313)
+
+	// Constraint for slot 3.12
+	atom, err := pkg.ParseAtom("dev-lang/python:3.12")
+	if err != nil {
+		t.Fatalf("ParseAtom error: %v", err)
+	}
+
+	err = adapter.AddAtomConstraint(atom)
+	if err != nil {
+		t.Fatalf("AddAtomConstraint() error: %v", err)
+	}
+
+	// Only one clause should be added (for 3.12.1)
+	if len(adapter.clauses) != 1 {
+		t.Errorf("Expected 1 clause, got %d", len(adapter.clauses))
+	}
+}
+
+// TestAtomMatches tests Atom.Matches with different packages
+func TestAtomMatches(t *testing.T) {
+	tests := []struct {
+		name      string
+		atomStr   string
+		pkg       *pkg.Package
+		wantMatch bool
+	}{
+		{
+			name:    "simple match",
+			atomStr: "sys-libs/glibc",
+			pkg: &pkg.Package{
+				Name:    "sys-libs/glibc",
+				Version: "2.38",
+				Slot:    pkg.Slot{Name: "2.38"},
+			},
+			wantMatch: true,
+		},
+		{
+			name:    "version match",
+			atomStr: ">=sys-libs/glibc-2.37",
+			pkg: &pkg.Package{
+				Name:    "sys-libs/glibc",
+				Version: "2.38",
+				Slot:    pkg.Slot{Name: "2.38"},
+			},
+			wantMatch: true,
+		},
+		{
+			name:    "version mismatch",
+			atomStr: ">=sys-libs/glibc-2.39",
+			pkg: &pkg.Package{
+				Name:    "sys-libs/glibc",
+				Version: "2.38",
+				Slot:    pkg.Slot{Name: "2.38"},
+			},
+			wantMatch: false,
+		},
+		{
+			name:    "slot match",
+			atomStr: "sys-libs/glibc:2.38",
+			pkg: &pkg.Package{
+				Name:    "sys-libs/glibc",
+				Version: "2.38",
+				Slot:    pkg.Slot{Name: "2.38"},
+			},
+			wantMatch: true,
+		},
+		{
+			name:    "slot mismatch",
+			atomStr: "sys-libs/glibc:2.37",
+			pkg: &pkg.Package{
+				Name:    "sys-libs/glibc",
+				Version: "2.38",
+				Slot:    pkg.Slot{Name: "2.38"},
+			},
+			wantMatch: false,
+		},
+		{
+			name:    "glob match",
+			atomStr: "=dev-lang/python-3.12*",
+			pkg: &pkg.Package{
+				Name:    "dev-lang/python",
+				Version: "3.12.1",
+				Slot:    pkg.Slot{Name: "3.12"},
+			},
+			wantMatch: true,
+		},
+		{
+			name:    "glob no match",
+			atomStr: "=dev-lang/python-3.11*",
+			pkg: &pkg.Package{
+				Name:    "dev-lang/python",
+				Version: "3.12.1",
+				Slot:    pkg.Slot{Name: "3.12"},
+			},
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			atom, err := pkg.ParseAtom(tt.atomStr)
+			if err != nil {
+				t.Fatalf("ParseAtom(%q) error: %v", tt.atomStr, err)
+			}
+
+			got := atom.Matches(tt.pkg)
+			if got != tt.wantMatch {
+				t.Errorf("Atom.Matches() = %v, want %v", got, tt.wantMatch)
+			}
+		})
+	}
+}

--- a/internal/solver/gophersat_adapter.go
+++ b/internal/solver/gophersat_adapter.go
@@ -95,6 +95,40 @@ func (g *GophersatAdapter) AddConstraint(c pkg.Constraint) error {
 	}
 }
 
+// AddAtomConstraint adds a constraint from a PMS-compliant Atom.
+// Uses Atom.Matches() for more accurate version/slot matching.
+func (g *GophersatAdapter) AddAtomConstraint(atom *pkg.Atom) error {
+	if atom == nil {
+		return fmt.Errorf("atom is nil")
+	}
+
+	pkgName := atom.CP()
+	log.Printf("Processing atom constraint: %s", atom.String())
+
+	// Collect all packages that match this atom
+	var satisfiedVars []int
+	for _, p := range g.packages[pkgName] {
+		if atom.Matches(p) {
+			key := p.Name + "@" + p.Version
+			varID := g.getVarID(key)
+			satisfiedVars = append(satisfiedVars, varID)
+			log.Printf("Package %s satisfies atom %s", key, atom.String())
+		} else {
+			log.Printf("Package %s does NOT satisfy atom %s",
+				p.Name+"@"+p.Version, atom.String())
+		}
+	}
+
+	if len(satisfiedVars) == 0 {
+		log.Printf("Warning: no package satisfies atom %s", atom.String())
+		return nil
+	}
+
+	// Add clause: at least one of the satisfying packages must be selected
+	g.addClause(satisfiedVars)
+	return nil
+}
+
 // AddOrGroupConstraint adds an OR-group constraint (at-least-one alternative)
 // For example: || ( mysql postgresql ) means "pick mysql OR postgresql"
 func (g *GophersatAdapter) AddOrGroupConstraint(alternatives []pkg.Constraint) error {

--- a/internal/state/sets_test.go
+++ b/internal/state/sets_test.go
@@ -595,6 +595,20 @@ func (r *mockRepo) Count() (int, error) {
 	return len(r.packages), nil
 }
 
+func (r *mockRepo) FindByAtom(atom *pkg.Atom) ([]*pkg.Package, error) {
+	if atom == nil {
+		return nil, repo.ErrPackageNotFound
+	}
+
+	var result []*pkg.Package
+	for _, p := range r.packages {
+		if atom.Matches(p) {
+			result = append(result, p)
+		}
+	}
+	return result, nil
+}
+
 func TestSetManager_CalculateUpdates(t *testing.T) {
 	// Create mock repository
 	mockRepository := newMockRepo()


### PR DESCRIPTION
## Summary

- **v0.3.0-002a**: Atom Parser Integration - integrate atom parser with ebuild_parser and SAT solver
- **v0.3.0-002b**: USE Flag Helpers - `use_enable`, `use_with` (1-4 args per PMS 11.3.2)
- **v0.3.0-002c**: EAPI 8 Helpers - `dosym -r`, `dostrip`, `einstalldocs`
- **v0.3.0-002d**: EAPI 8 Variables - IDEPEND, REQUIRED_USE (||, ^^, ??), PROPERTIES, RESTRICT
- **v0.3.0-002e**: SRC_URI Enhancements - arrow syntax, USE-conditional downloads

## New Files

- `internal/pkg/required_use.go` - REQUIRED_USE expression validator (PMS 7.2.6)
- `internal/repo/srcuri_parser.go` - SRC_URI parser with arrow syntax
- `internal/fetch/srcuri.go` - Fetch system integration

## Test plan

- [x] All unit tests pass
- [x] golangci-lint: 0 issues
- [x] gofmt applied
- [ ] CI checks pass