### PR TITLE
docs: update documentation for v0.3.0-002 EAPI 8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Atom.ToConstraint()` for solver integration
 - Full test coverage (30+ test cases)
 
+#### Full EAPI 8 Support (v0.3.0-002)
+- **REQUIRED_USE validator** - Full expression parsing (||, ^^, ??, flag?, !flag?, conditionals)
+- **SRC_URI enhancements** - Arrow syntax (`-> filename`), USE-conditional downloads
+- **USE flag helpers** - `use_enable`, `use_with` (1-4 argument modes per PMS 11.3.2)
+- **EAPI 8 installation helpers** - `dosym -r` (relative symlinks), `dostrip`, `einstalldocs`
+- **New ebuild variables** - IDEPEND, PROPERTIES, RESTRICT parsing
+- **Atom parser integration** - `FindByAtom()` in Repository, `AddAtomConstraint()` in SAT solver
+- Full test coverage for all new features
+
 ### Planned
-- Full EAPI 8 support (v0.3.0-002)
 - GoSh integration for bash compatibility (v0.3.0-003)
 - CMake/Meson build systems
 - Performance optimization for large dependency graphs

--- a/README.md
+++ b/README.md
@@ -162,15 +162,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines and [AGENTS.md
 
 ## Roadmap
 
-**v0.1.1** (Current) — Module architecture improvements, real eclass support, proper phase dispatch.
+**v0.2.0** (Released) — Ebuild parser improvements, variable expansion, xargs helper.
 
-**v0.2.0** (Next) — Ebuild parser improvements:
-- Variable expansion (`${P}`, `${PV}`)
-- xargs helper implementation
-
-**v0.3.0** — PMS compliance:
-- PMS-compliant atom parser
-- Full EAPI 8 support
+**v0.3.0** (In Progress) — PMS compliance:
+- ✅ PMS-compliant atom parser
+- ✅ Full EAPI 8 support (REQUIRED_USE, SRC_URI arrow, IDEPEND, use_enable/use_with, dosym -r)
+- ⏸️ GoSh integration (blocked, waiting for gosh library)
 
 **v1.0.0** — Production ready after community validation (no fixed date).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,8 +26,8 @@ GRPM aims to be a modern, reliable package manager for Gentoo Linux with:
 | Task | Status | Description |
 |------|--------|-------------|
 | Atom Parser | ✅ Done | PMS Section 8.3 compliant parser |
-| EAPI 8 | 🔲 TODO | Full EAPI 8 feature support |
-| GoSh Integration | 🔲 TODO | Replace mvdan.cc/sh with GoSh |
+| EAPI 8 | ✅ Done | Full EAPI 8 feature support |
+| GoSh Integration | ⏸️ Blocked | Replace mvdan.cc/sh with GoSh (waiting for gosh library) |
 
 ---
 
@@ -92,8 +92,8 @@ No fixed timeline for v1.0.0 — quality and stability over deadlines.
 ### Near-term (v0.3.0)
 
 - [x] PMS-compliant atom parser (Section 8.3)
-- [ ] Full EAPI 8 support
-- [ ] GoSh integration (bash compatibility)
+- [x] Full EAPI 8 support (REQUIRED_USE, SRC_URI arrow, IDEPEND, use_enable/use_with, dosym -r, dostrip, einstalldocs)
+- [ ] GoSh integration (bash compatibility) — blocked, waiting for gosh library
 - [ ] Improved error messages and diagnostics
 
 ### Medium-term (v0.4.0+)


### PR DESCRIPTION
Update CHANGELOG, README, and ROADMAP to reflect v0.3.0-002 completion.

- Mark EAPI 8 support as done
- Update roadmap status
- Add feature details to changelog