### PR TITLE
fix(pkg): implement PMS-compliant version comparison (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.1] - 2026-01-09
+
+### Fixed
+
+#### PMS-Compliant Version Comparison (v0.2.1-001, v0.2.1-002, v0.2.1-003)
+
+Critical bug fixes for version comparison per PMS Chapter 3.2-3.3:
+
+- **Version suffix ordering** - Implemented PMS Algorithm 3.5-3.6:
+  - Correct: `_alpha < _beta < _pre < _rc < (release) < _p`
+  - Previously: Used alphabetical comparison (`_p < _pre < _rc`)
+  - **Impact**: Fixes incorrect package version selection during dependency resolution
+
+- **Leading zero handling** - Implemented PMS Algorithm 3.3:
+  - Components with leading zeros compared lexicographically
+  - Trailing zeros stripped before comparison
+
+- **Letter suffix parsing** - Implemented PMS Section 3.2:
+  - Single letter suffix (`1.0a`, `1.0b`) parsed separately
+  - Correct ordering: `1.0a < 1.0b < 1.0z < 1.0` (letter < no letter)
+
+- **Revision handling** - `-r0` now equals no revision per PMS
+
+### Changed
+
+- `Version` struct refactored to rich domain model with:
+  - `VersionComponent` - numeric parts with leading zero tracking
+  - `VersionSuffix` - suffix type and number
+  - `letterSuffix` field for single letter
+  - `revision` field for `-rN`
+- Comprehensive test suite for PMS compliance (30+ new test cases)
+
+---
+
 ## [0.2.0] - 2026-01-09
 
 ### Ebuild Parser Improvements

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 GRPM (Go Resource Package Manager) is a modern source-based package manager written in Go, inspired by and fully compatible with **Gentoo's Portage**. It brings SAT-based dependency resolution, transactional updates with filesystem snapshots, and binary package support. While rooted in the Gentoo ecosystem, GRPM is designed to be distribution-agnostic and extensible for any Linux distribution.
 
-**Current Version:** v0.2.0 (January 2026)
+**Current Version:** v0.2.1 (January 2026)
 
 ---
 

--- a/internal/pkg/constraint.go
+++ b/internal/pkg/constraint.go
@@ -1,7 +1,6 @@
 package pkg
 
 import (
-	"strconv"
 	"strings"
 )
 
@@ -137,27 +136,32 @@ func (vc *VersionConstraint) Satisfies(version string) bool {
 	}
 }
 
-// CompareVersions compares two Gentoo-format version strings
+// CompareVersions compares two Gentoo-format version strings per PMS Chapter 3.2-3.3.
 // Returns: <0 if v1<v2, 0 if v1==v2, >0 if v1>v2
+//
+// This implements the full PMS version comparison algorithm:
+// - Suffix ordering: _alpha < _beta < _pre < _rc < (release) < _p
+// - Letter suffix: 1.0a < 1.0b < 1.0 (no letter is newest)
+// - Leading zeros: compared lexicographically after stripping trailing zeros
+// - Revisions: -r1, -r2, etc.
 func CompareVersions(v1, v2 string) int {
-	// Split versions into components: 1.2.3_alpha4-r5 -> [1, 2, 3, "alpha", 4, 5]
-	// Uses precompiled regex from version.go for performance
-	splitVersion := func(v string) []interface{} {
-		parts := versionComponentsRe.FindAllString(v, -1)
+	// Parse both versions using the PMS-compliant parser
+	ver1, err1 := parseVersion(v1)
+	ver2, err2 := parseVersion(v2)
 
-		var result []interface{}
-		for _, part := range parts {
-			if num, err := strconv.Atoi(part); err == nil {
-				result = append(result, num)
-			} else {
-				result = append(result, part)
-			}
-		}
-		return result
+	// If parsing fails, fall back to legacy comparison
+	if err1 != nil || err2 != nil {
+		return legacyCompareVersions(v1, v2)
 	}
 
-	parts1 := splitVersion(v1)
-	parts2 := splitVersion(v2)
+	return compareVersions(ver1, ver2)
+}
+
+// legacyCompareVersions provides backward-compatible version comparison
+// for versions that don't parse with the strict PMS parser.
+func legacyCompareVersions(v1, v2 string) int {
+	parts1 := legacyParseComponents(v1)
+	parts2 := legacyParseComponents(v2)
 
 	// Compare components
 	for i := 0; i < len(parts1) && i < len(parts2); i++ {

--- a/internal/pkg/version.go
+++ b/internal/pkg/version.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -10,41 +11,82 @@ import (
 
 // Precompiled regex patterns for performance (compiled once at package init).
 var (
-	// versionComponentsRe extracts numeric and alphabetic components from version strings.
-	// Example: "1.2.3_alpha4" -> ["1", "2", "3", "alpha", "4"]
-	versionComponentsRe = coregex.MustCompile(`(\d+)|([a-zA-Z]+)`)
+	// versionMainRe extracts the main version components before any suffix.
+	// Matches: numeric.numeric.numeric[letter]
+	// Example: "1.2.3a" from "1.2.3a_alpha1-r2"
+	versionMainRe = coregex.MustCompile(`^(\d+(?:\.\d+)*)([a-z])?`)
+
+	// versionSuffixRe extracts suffixes like _alpha1, _beta2, _pre3, _rc4, _p5
+	versionSuffixRe = coregex.MustCompile(`_(alpha|beta|pre|rc|p)(\d*)`)
+
+	// versionRevisionRe extracts the revision number -rN
+	versionRevisionRe = coregex.MustCompile(`-r(\d+)$`)
 
 	// versionDigitRe validates that a version contains at least one digit.
-	versionDigitRe = coregex.MustCompile(`\d`)
+	versionDigitRe = coregex.MustCompile(`^\d`)
 )
 
-// Version is a Value Object representing a Gentoo package version
-// It is immutable and self-validating
-type Version struct {
-	raw        string
-	components []interface{} // Parsed version components
+// ErrEmptyVersion is returned when an empty version string is provided.
+var ErrEmptyVersion = errors.New("version cannot be empty")
+
+// errVersionInvalid is a local error for version parsing failures.
+// Note: ErrInvalidVersion is defined in atom.go with package-level scope.
+var errVersionInvalid = errors.New("invalid version format")
+
+// suffixPriority defines the ordering of version suffixes per PMS Algorithm 3.5-3.6.
+// _alpha < _beta < _pre < _rc < (no suffix) < _p
+var suffixPriority = map[string]int{
+	"alpha": -4,
+	"beta":  -3,
+	"pre":   -2,
+	"rc":    -1,
+	"":      0, // no suffix = release
+	"p":     1, // patchlevel is AFTER release
 }
 
-// NewVersion creates a new Version instance with validation
+// VersionComponent represents a single numeric component of a version.
+// Per PMS Algorithm 3.3, components with leading zeros are compared specially.
+type VersionComponent struct {
+	Value          int    // Numeric value (for non-leading-zero comparison)
+	HasLeadingZero bool   // True if component started with 0 and has multiple digits
+	Original       string // Original string for leading zero comparison
+}
+
+// VersionSuffix represents a version suffix like _alpha1 or _beta2.
+type VersionSuffix struct {
+	Type   string // "alpha", "beta", "pre", "rc", "p"
+	Number int    // suffix number (1 in _alpha1, 0 if no number)
+}
+
+// Version is a Value Object representing a Gentoo package version.
+// It implements PMS Chapter 3.2-3.3 version comparison algorithm.
+// The struct is immutable and self-validating.
+type Version struct {
+	raw          string             // Original version string
+	components   []VersionComponent // Numeric parts (1.2.3 -> [1, 2, 3])
+	letterSuffix string             // Single letter suffix "a"-"z" or ""
+	suffixes     []VersionSuffix    // _alpha1, _beta2, etc.
+	revision     int                // -r1, -r2, etc. (0 means no revision)
+}
+
+// NewVersion creates a new Version instance with validation.
+// Parses version according to PMS Chapter 3.2 format:
+// [0-9]+(\.[0-9]+)*[a-z]?(_suffix[0-9]*)*(-r[0-9]+)?
 func NewVersion(versionStr string) (Version, error) {
 	if versionStr == "" {
-		return Version{}, fmt.Errorf("version cannot be empty")
+		return Version{}, ErrEmptyVersion
 	}
 
-	// Validate version format (basic check)
-	if !isValidVersionFormat(versionStr) {
-		return Version{}, fmt.Errorf("invalid version format: %s", versionStr)
+	// Parse the version string
+	v, err := parseVersion(versionStr)
+	if err != nil {
+		return Version{}, fmt.Errorf("%w: %s", errVersionInvalid, versionStr)
 	}
 
-	components := parseVersionComponents(versionStr)
-
-	return Version{
-		raw:        versionStr,
-		components: components,
-	}, nil
+	return v, nil
 }
 
-// MustNewVersion creates a Version or panics if invalid (use in tests/constants)
+// MustNewVersion creates a Version or panics if invalid (use in tests/constants).
 func MustNewVersion(versionStr string) Version {
 	v, err := NewVersion(versionStr)
 	if err != nil {
@@ -53,46 +95,274 @@ func MustNewVersion(versionStr string) Version {
 	return v
 }
 
-// String returns the string representation of the version
+// String returns the string representation of the version.
 func (v Version) String() string {
 	return v.raw
 }
 
-// Equals checks if two versions are equal (Value Object equality)
+// Equals checks if two versions are equal (Value Object equality).
 func (v Version) Equals(other Version) bool {
 	return v.raw == other.raw
 }
 
-// CompareTo compares this version with another
+// CompareTo compares this version with another per PMS Algorithm 3.2.
 // Returns: <0 if v<other, 0 if v==other, >0 if v>other
 func (v Version) CompareTo(other Version) int {
-	return compareVersionComponents(v.components, other.components)
+	return compareVersions(v, other)
 }
 
-// IsGreaterThan checks if this version is greater than another
+// IsGreaterThan checks if this version is greater than another.
 func (v Version) IsGreaterThan(other Version) bool {
 	return v.CompareTo(other) > 0
 }
 
-// IsLessThan checks if this version is less than another
+// IsLessThan checks if this version is less than another.
 func (v Version) IsLessThan(other Version) bool {
 	return v.CompareTo(other) < 0
 }
 
-// IsGreaterThanOrEqual checks if this version is >= another
+// IsGreaterThanOrEqual checks if this version is >= another.
 func (v Version) IsGreaterThanOrEqual(other Version) bool {
 	return v.CompareTo(other) >= 0
 }
 
-// IsLessThanOrEqual checks if this version is <= another
+// IsLessThanOrEqual checks if this version is <= another.
 func (v Version) IsLessThanOrEqual(other Version) bool {
 	return v.CompareTo(other) <= 0
 }
 
-// parseVersionComponents splits version into components: 1.2.3_alpha4-r5 -> [1, 2, 3, "alpha", 4, 5]
-func parseVersionComponents(v string) []interface{} {
-	// Separate digits and letters using precompiled regex
-	parts := versionComponentsRe.FindAllString(v, -1)
+// parseVersion parses a Gentoo version string into structured components.
+func parseVersion(s string) (Version, error) {
+	if s == "" {
+		return Version{}, errors.New("empty version")
+	}
+
+	// Must start with a digit
+	if !versionDigitRe.MatchString(s) {
+		return Version{}, errors.New("version must start with digit")
+	}
+
+	v := Version{raw: s}
+	remaining := s
+
+	// Step 1: Extract revision (-rN) from the end
+	if revMatch := versionRevisionRe.FindStringSubmatch(remaining); revMatch != nil {
+		revNum, err := strconv.Atoi(revMatch[1])
+		if err != nil {
+			return Version{}, fmt.Errorf("invalid revision: %s", revMatch[1])
+		}
+		v.revision = revNum
+		remaining = remaining[:len(remaining)-len(revMatch[0])]
+	}
+
+	// Step 2: Extract suffixes (_alpha1, _beta2, etc.)
+	suffixMatches := versionSuffixRe.FindAllStringSubmatchIndex(remaining, -1)
+	if len(suffixMatches) > 0 {
+		// Find where suffixes start
+		suffixStart := suffixMatches[0][0]
+		suffixPart := remaining[suffixStart:]
+		remaining = remaining[:suffixStart]
+
+		// Parse each suffix
+		for _, match := range versionSuffixRe.FindAllStringSubmatch(suffixPart, -1) {
+			suffix := VersionSuffix{Type: match[1]}
+			if match[2] != "" {
+				num, err := strconv.Atoi(match[2])
+				if err != nil {
+					return Version{}, fmt.Errorf("invalid suffix number: %s", match[2])
+				}
+				suffix.Number = num
+			}
+			v.suffixes = append(v.suffixes, suffix)
+		}
+	}
+
+	// Step 3: Extract main version and letter suffix
+	mainMatch := versionMainRe.FindStringSubmatch(remaining)
+	if mainMatch == nil {
+		return Version{}, errors.New("invalid main version format")
+	}
+
+	// Parse numeric components
+	numericPart := mainMatch[1]
+	parts := strings.Split(numericPart, ".")
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		comp := VersionComponent{
+			Original:       part,
+			HasLeadingZero: len(part) > 1 && part[0] == '0',
+		}
+		num, err := strconv.Atoi(part)
+		if err != nil {
+			return Version{}, fmt.Errorf("invalid numeric component: %s", part)
+		}
+		comp.Value = num
+		v.components = append(v.components, comp)
+	}
+
+	// Extract letter suffix if present
+	if len(mainMatch) > 2 && mainMatch[2] != "" {
+		v.letterSuffix = mainMatch[2]
+	}
+
+	if len(v.components) == 0 {
+		return Version{}, errors.New("no numeric components found")
+	}
+
+	return v, nil
+}
+
+// compareVersions implements PMS Algorithm 3.2 for version comparison.
+func compareVersions(v1, v2 Version) int {
+	// Step 1: Compare numeric components
+	maxLen := len(v1.components)
+	if len(v2.components) > maxLen {
+		maxLen = len(v2.components)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		var c1, c2 VersionComponent
+
+		if i < len(v1.components) {
+			c1 = v1.components[i]
+		} else {
+			// Missing component treated as 0
+			c1 = VersionComponent{Value: 0, Original: "0"}
+		}
+
+		if i < len(v2.components) {
+			c2 = v2.components[i]
+		} else {
+			// Missing component treated as 0
+			c2 = VersionComponent{Value: 0, Original: "0"}
+		}
+
+		cmp := compareComponents(c1, c2)
+		if cmp != 0 {
+			return cmp
+		}
+	}
+
+	// Step 2: Compare letter suffix (PMS Algorithm 3.4)
+	// No letter > letter (e.g., 1.0 > 1.0z > 1.0a)
+	cmp := compareLetterSuffix(v1.letterSuffix, v2.letterSuffix)
+	if cmp != 0 {
+		return cmp
+	}
+
+	// Step 3: Compare suffixes (_alpha, _beta, _pre, _rc, _p)
+	cmp = compareSuffixes(v1.suffixes, v2.suffixes)
+	if cmp != 0 {
+		return cmp
+	}
+
+	// Step 4: Compare revisions
+	return v1.revision - v2.revision
+}
+
+// compareComponents compares two version components per PMS Algorithm 3.3.
+func compareComponents(c1, c2 VersionComponent) int {
+	// If either has leading zeros, use special comparison
+	if c1.HasLeadingZero || c2.HasLeadingZero {
+		return compareWithLeadingZeros(c1.Original, c2.Original)
+	}
+
+	// Standard numeric comparison
+	return c1.Value - c2.Value
+}
+
+// compareWithLeadingZeros implements PMS Algorithm 3.3 for leading zero comparison.
+// 1. Strip trailing zeros from both strings
+// 2. Compare lexicographically (ASCII)
+func compareWithLeadingZeros(s1, s2 string) int {
+	// Strip trailing zeros
+	s1 = strings.TrimRight(s1, "0")
+	s2 = strings.TrimRight(s2, "0")
+
+	// Handle empty results (all zeros)
+	if s1 == "" {
+		s1 = "0"
+	}
+	if s2 == "" {
+		s2 = "0"
+	}
+
+	// Lexicographic comparison
+	return strings.Compare(s1, s2)
+}
+
+// compareLetterSuffix compares letter suffixes per PMS Algorithm 3.4.
+// No letter > any letter, and letters compare alphabetically.
+func compareLetterSuffix(l1, l2 string) int {
+	// Both have no letter - equal
+	if l1 == "" && l2 == "" {
+		return 0
+	}
+	// No letter > letter
+	if l1 == "" && l2 != "" {
+		return 1
+	}
+	if l1 != "" && l2 == "" {
+		return -1
+	}
+	// Both have letters - compare alphabetically
+	return strings.Compare(l1, l2)
+}
+
+// compareSuffixes compares version suffixes per PMS Algorithm 3.5-3.6.
+// Order: _alpha < _beta < _pre < _rc < (no suffix) < _p
+func compareSuffixes(s1, s2 []VersionSuffix) int {
+	maxLen := len(s1)
+	if len(s2) > maxLen {
+		maxLen = len(s2)
+	}
+
+	// If no suffixes on either side, they're equal
+	if maxLen == 0 {
+		return 0
+	}
+
+	for i := 0; i < maxLen; i++ {
+		var suf1, suf2 VersionSuffix
+
+		if i < len(s1) {
+			suf1 = s1[i]
+		} else {
+			// No more suffixes means release version (priority 0)
+			suf1 = VersionSuffix{Type: "", Number: 0}
+		}
+
+		if i < len(s2) {
+			suf2 = s2[i]
+		} else {
+			// No more suffixes means release version (priority 0)
+			suf2 = VersionSuffix{Type: "", Number: 0}
+		}
+
+		// Compare by suffix type priority
+		p1 := suffixPriority[suf1.Type]
+		p2 := suffixPriority[suf2.Type]
+
+		if p1 != p2 {
+			return p1 - p2
+		}
+
+		// Same type - compare by number
+		if suf1.Number != suf2.Number {
+			return suf1.Number - suf2.Number
+		}
+	}
+
+	return 0
+}
+
+// legacyParseComponents provides fallback parsing for backward compatibility.
+func legacyParseComponents(v string) []interface{} {
+	// Use simple regex to extract components
+	re := coregex.MustCompile(`(\d+)|([a-zA-Z]+)`)
+	parts := re.FindAllString(v, -1)
 
 	var result []interface{}
 	for _, part := range parts {
@@ -103,40 +373,4 @@ func parseVersionComponents(v string) []interface{} {
 		}
 	}
 	return result
-}
-
-// compareVersionComponents compares two parsed version component slices
-func compareVersionComponents(v1, v2 []interface{}) int {
-	// Compare components
-	for i := 0; i < len(v1) && i < len(v2); i++ {
-		switch a := v1[i].(type) {
-		case int:
-			if b, ok := v2[i].(int); ok {
-				if a != b {
-					return a - b
-				}
-			} else {
-				// Numbers are always greater than strings
-				return 1
-			}
-		case string:
-			if b, ok := v2[i].(string); ok {
-				if cmp := strings.Compare(a, b); cmp != 0 {
-					return cmp
-				}
-			} else {
-				// Strings are always less than numbers
-				return -1
-			}
-		}
-	}
-
-	// If all components are equal, the longer version is considered greater
-	return len(v1) - len(v2)
-}
-
-// isValidVersionFormat performs basic validation of Gentoo version format
-func isValidVersionFormat(v string) bool {
-	// Basic validation: must contain at least one digit
-	return versionDigitRe.MatchString(v)
 }

--- a/internal/pkg/version_test.go
+++ b/internal/pkg/version_test.go
@@ -66,6 +66,30 @@ func TestNewVersion_ValidVersions(t *testing.T) {
 			expectedRaw: "1.2.3.4.5.6",
 			shouldError: false,
 		},
+		{
+			name:        "Version with letter suffix",
+			versionStr:  "1.0a",
+			expectedRaw: "1.0a",
+			shouldError: false,
+		},
+		{
+			name:        "Version with letter and _suffix",
+			versionStr:  "1.0a_alpha1",
+			expectedRaw: "1.0a_alpha1",
+			shouldError: false,
+		},
+		{
+			name:        "Version with patchlevel",
+			versionStr:  "1.0_p1",
+			expectedRaw: "1.0_p1",
+			shouldError: false,
+		},
+		{
+			name:        "Version with leading zeros",
+			versionStr:  "1.01.002",
+			expectedRaw: "1.01.002",
+			shouldError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -270,21 +294,144 @@ func TestVersion_CompareTo(t *testing.T) {
 			expected: 1,
 		},
 
-		// Alpha/Beta/RC comparisons (alphabetical string comparison)
+		// ========================================
+		// v0.2.1-001: Suffix Ordering (PMS 3.5-3.6)
+		// CRITICAL: _alpha < _beta < _pre < _rc < (release) < _p
+		// ========================================
 		{
-			name:     "Alpha before beta (1.0_alpha < 1.0_beta)",
+			name:     "v0.2.1-001: alpha < beta",
+			v1:       "1.0_alpha",
+			v2:       "1.0_beta",
+			expected: -1,
+		},
+		{
+			name:     "v0.2.1-001: alpha1 < beta1",
 			v1:       "1.0_alpha1",
 			v2:       "1.0_beta1",
 			expected: -1,
 		},
 		{
-			name:     "Beta before rc (1.0_beta < 1.0_rc)",
-			v1:       "1.0_beta1",
-			v2:       "1.0_rc1",
+			name:     "v0.2.1-001: beta < pre",
+			v1:       "1.0_beta",
+			v2:       "1.0_pre",
 			expected: -1,
 		},
 		{
-			name:     "Different alpha numbers (alpha1 < alpha2)",
+			name:     "v0.2.1-001: pre < rc",
+			v1:       "1.0_pre",
+			v2:       "1.0_rc",
+			expected: -1,
+		},
+		{
+			name:     "v0.2.1-001: rc < release (no suffix)",
+			v1:       "1.0_rc1",
+			v2:       "1.0",
+			expected: -1,
+		},
+		{
+			name:     "v0.2.1-001: release < patchlevel",
+			v1:       "1.0",
+			v2:       "1.0_p1",
+			expected: -1,
+		},
+		{
+			name:     "v0.2.1-001: CRITICAL - rc1 < p1 (was bug: p < rc alphabetically)",
+			v1:       "1.0_rc1",
+			v2:       "1.0_p1",
+			expected: -1,
+		},
+		{
+			name:     "v0.2.1-001: alpha < p (full chain)",
+			v1:       "1.0_alpha1",
+			v2:       "1.0_p1",
+			expected: -1,
+		},
+		{
+			name:     "v0.2.1-001: pre release before stable",
+			v1:       "1.0_pre20231201",
+			v2:       "1.0",
+			expected: -1,
+		},
+
+		// ========================================
+		// v0.2.1-003: Letter Suffix (PMS 3.4)
+		// CRITICAL: 1.0a < 1.0b < ... < 1.0z < 1.0 (no letter is newest)
+		// ========================================
+		{
+			name:     "v0.2.1-003: 1.0a < 1.0b",
+			v1:       "1.0a",
+			v2:       "1.0b",
+			expected: -1,
+		},
+		{
+			name:     "v0.2.1-003: 1.0y < 1.0z",
+			v1:       "1.0y",
+			v2:       "1.0z",
+			expected: -1,
+		},
+		{
+			name:     "v0.2.1-003: letter < no letter (1.0z < 1.0)",
+			v1:       "1.0z",
+			v2:       "1.0",
+			expected: -1,
+		},
+		{
+			name:     "v0.2.1-003: no letter > letter (1.0 > 1.0a)",
+			v1:       "1.0",
+			v2:       "1.0a",
+			expected: 1,
+		},
+		{
+			name:     "v0.2.1-003: letter with suffix (1.0a_alpha < 1.0a_beta)",
+			v1:       "1.0a_alpha",
+			v2:       "1.0a_beta",
+			expected: -1,
+		},
+		{
+			name:     "v0.2.1-003: 1.0a < 1.0b_alpha (letter takes precedence)",
+			v1:       "1.0a",
+			v2:       "1.0b_alpha",
+			expected: -1,
+		},
+
+		// ========================================
+		// v0.2.1-002: Leading Zeros (PMS 3.3)
+		// CRITICAL: strip trailing zeros, compare lexicographically
+		// ========================================
+		{
+			name:     "v0.2.1-002: 1.01 < 1.1 (leading zero lexicographic)",
+			v1:       "1.01",
+			v2:       "1.1",
+			expected: -1,
+		},
+		{
+			name:     "v0.2.1-002: 1.010 vs 1.01 (trailing zeros stripped)",
+			v1:       "1.010",
+			v2:       "1.01",
+			expected: 0,
+		},
+		{
+			name:     "v0.2.1-002: 1.001 < 1.01",
+			v1:       "1.001",
+			v2:       "1.01",
+			expected: -1,
+		},
+		{
+			name:     "v0.2.1-002: 1.02 > 1.01",
+			v1:       "1.02",
+			v2:       "1.01",
+			expected: 1,
+		},
+
+		// Combined scenarios
+		{
+			name:     "Combined: letter + suffix (1.0a_alpha < 1.0a_beta)",
+			v1:       "1.0a_alpha",
+			v2:       "1.0a_beta",
+			expected: -1,
+		},
+		{
+			name:     "Combined: different alpha numbers (alpha1 < alpha2)",
 			v1:       "1.0_alpha1",
 			v2:       "1.0_alpha2",
 			expected: -1,
@@ -303,31 +450,25 @@ func TestVersion_CompareTo(t *testing.T) {
 			v2:       "1.0-r1",
 			expected: -1,
 		},
+		{
+			name:     "Revision with patchlevel (1.0_p1-r1 < 1.0_p1-r2)",
+			v1:       "1.0_p1-r1",
+			v2:       "1.0_p1-r2",
+			expected: -1,
+		},
 
 		// Complex Gentoo-specific versions
-		// TODO: Known Issue - Pre-release semantics not yet implemented
-		// In Gentoo: 1.0_pre < 1.0_alpha < 1.0_beta < 1.0_rc < 1.0 (stable)
-		// Current implementation treats longer version as greater (incorrect for pre/alpha/beta/rc)
-		// Will fix in separate commit after implementing proper Gentoo version semantics
-		// {
-		// 	name:     "Pre-release before stable (1.0_pre < 1.0)",
-		// 	v1:       "1.0_pre20231201",
-		// 	v2:       "1.0",
-		// 	expected: -1,
-		// },
 		{
 			name:     "Complex comparison with all components",
 			v1:       "1.2.3_alpha4-r5",
 			v2:       "1.2.3_alpha5-r1",
 			expected: -1,
 		},
-
-		// Edge cases: numbers vs strings
 		{
-			name:     "Number component > string component",
-			v1:       "1.2.3",
-			v2:       "1.2.alpha",
-			expected: 1,
+			name:     "Complex: same base, different suffix type",
+			v1:       "1.2.3_beta1",
+			v2:       "1.2.3_rc1",
+			expected: -1,
 		},
 	}
 
@@ -347,7 +488,8 @@ func TestVersion_CompareTo(t *testing.T) {
 			}
 
 			if normalizedResult != tt.expected {
-				t.Errorf("Version(%q).CompareTo(%q) = %d, expected %d", tt.v1, tt.v2, normalizedResult, tt.expected)
+				t.Errorf("Version(%q).CompareTo(%q) = %d (raw: %d), expected %d",
+					tt.v1, tt.v2, normalizedResult, result, tt.expected)
 			}
 
 			// Test anti-symmetry: v1.CompareTo(v2) == -v2.CompareTo(v1)
@@ -355,6 +497,166 @@ func TestVersion_CompareTo(t *testing.T) {
 			if result != -reverse {
 				t.Errorf("CompareTo() not anti-symmetric: %q.CompareTo(%q)=%d, but %q.CompareTo(%q)=%d",
 					tt.v1, tt.v2, result, tt.v2, tt.v1, reverse)
+			}
+		})
+	}
+}
+
+// TestCompareVersions_PMSCompliance tests CompareVersions function directly
+// to ensure PMS Chapter 3.2-3.3 compliance
+func TestCompareVersions_PMSCompliance(t *testing.T) {
+	tests := []struct {
+		name     string
+		v1       string
+		v2       string
+		expected int
+	}{
+		// v0.2.1-001: Suffix ordering
+		{"suffix: alpha < beta", "1.0_alpha", "1.0_beta", -1},
+		{"suffix: beta < pre", "1.0_beta", "1.0_pre", -1},
+		{"suffix: pre < rc", "1.0_pre", "1.0_rc", -1},
+		{"suffix: rc < release", "1.0_rc", "1.0", -1},
+		{"suffix: release < p", "1.0", "1.0_p", -1},
+		{"suffix: CRITICAL rc < p", "1.0_rc1", "1.0_p1", -1},
+
+		// v0.2.1-002: Leading zeros (not currently triggered in test versions)
+		// Note: PMS says leading zero comparison is lexicographic after stripping trailing zeros
+
+		// v0.2.1-003: Letter suffix
+		{"letter: a < b", "1.0a", "1.0b", -1},
+		{"letter: z < (none)", "1.0z", "1.0", -1},
+		{"letter: (none) > a", "1.0", "1.0a", 1},
+
+		// Revisions
+		{"revision: r0 == no revision", "1.0-r0", "1.0", 0},
+		{"revision: r1 < r2", "1.0-r1", "1.0-r2", -1},
+
+		// Complex combinations
+		{"complex: 1.2.3_alpha < 1.2.3", "1.2.3_alpha", "1.2.3", -1},
+		{"complex: 1.2.3 < 1.2.3_p1", "1.2.3", "1.2.3_p1", -1},
+		{"complex: full chain", "1.0_alpha1", "1.0_p1", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CompareVersions(tt.v1, tt.v2)
+
+			// Normalize to -1, 0, 1
+			normalized := 0
+			if result < 0 {
+				normalized = -1
+			} else if result > 0 {
+				normalized = 1
+			}
+
+			if normalized != tt.expected {
+				t.Errorf("CompareVersions(%q, %q) = %d, expected %d",
+					tt.v1, tt.v2, normalized, tt.expected)
+			}
+		})
+	}
+}
+
+// TestVersion_SuffixOrdering_Comprehensive tests all suffix orderings exhaustively
+func TestVersion_SuffixOrdering_Comprehensive(t *testing.T) {
+	// Define the correct order per PMS Algorithm 3.5-3.6
+	// _alpha < _beta < _pre < _rc < (no suffix) < _p
+	orderedVersions := []string{
+		"1.0_alpha",
+		"1.0_alpha1",
+		"1.0_alpha2",
+		"1.0_beta",
+		"1.0_beta1",
+		"1.0_pre",
+		"1.0_pre1",
+		"1.0_rc",
+		"1.0_rc1",
+		"1.0_rc2",
+		"1.0", // release
+		"1.0_p",
+		"1.0_p1",
+		"1.0_p2",
+	}
+
+	for i := 0; i < len(orderedVersions)-1; i++ {
+		for j := i + 1; j < len(orderedVersions); j++ {
+			v1 := MustNewVersion(orderedVersions[i])
+			v2 := MustNewVersion(orderedVersions[j])
+
+			result := v1.CompareTo(v2)
+			if result >= 0 {
+				t.Errorf("Expected %q < %q, but CompareTo returned %d",
+					orderedVersions[i], orderedVersions[j], result)
+			}
+
+			// Also test reverse
+			reverseResult := v2.CompareTo(v1)
+			if reverseResult <= 0 {
+				t.Errorf("Expected %q > %q, but CompareTo returned %d",
+					orderedVersions[j], orderedVersions[i], reverseResult)
+			}
+		}
+	}
+}
+
+// TestVersion_LetterSuffix_Comprehensive tests letter suffix ordering
+func TestVersion_LetterSuffix_Comprehensive(t *testing.T) {
+	// Per PMS 3.4: 1.0a < 1.0b < ... < 1.0z < 1.0 (no letter)
+	letters := "abcdefghijklmnopqrstuvwxyz"
+	versions := make([]string, len(letters)+1)
+
+	for i, ch := range letters {
+		versions[i] = "1.0" + string(ch)
+	}
+	versions[len(letters)] = "1.0" // no letter is last (highest)
+
+	for i := 0; i < len(versions)-1; i++ {
+		for j := i + 1; j < len(versions); j++ {
+			v1 := MustNewVersion(versions[i])
+			v2 := MustNewVersion(versions[j])
+
+			result := v1.CompareTo(v2)
+			if result >= 0 {
+				t.Errorf("Expected %q < %q, but CompareTo returned %d",
+					versions[i], versions[j], result)
+			}
+		}
+	}
+}
+
+// TestVersion_LeadingZeros tests PMS Algorithm 3.3 leading zero comparison
+func TestVersion_LeadingZeros(t *testing.T) {
+	tests := []struct {
+		name     string
+		v1       string
+		v2       string
+		expected int
+	}{
+		// Leading zero triggers lexicographic comparison after stripping trailing zeros
+		{"01 vs 1: leading zero triggers special comparison", "1.01", "1.1", -1},
+		{"010 vs 01: trailing zeros stripped, equal", "1.010", "1.01", 0},
+		{"001 vs 01: lexicographic 001 < 01", "1.001", "1.01", -1},
+		{"02 vs 01: 02 > 01", "1.02", "1.01", 1},
+		{"0 vs 00: both normalize to same", "1.0", "1.00", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v1 := MustNewVersion(tt.v1)
+			v2 := MustNewVersion(tt.v2)
+
+			result := v1.CompareTo(v2)
+
+			normalized := 0
+			if result < 0 {
+				normalized = -1
+			} else if result > 0 {
+				normalized = 1
+			}
+
+			if normalized != tt.expected {
+				t.Errorf("Version(%q).CompareTo(%q) = %d, expected %d",
+					tt.v1, tt.v2, normalized, tt.expected)
 			}
 		})
 	}
@@ -385,6 +687,18 @@ func TestVersion_IsGreaterThan(t *testing.T) {
 			v1:       "1.0.0",
 			v2:       "1.0.0",
 			expected: false,
+		},
+		{
+			name:     "1.0_p1 > 1.0 (patchlevel > release)",
+			v1:       "1.0_p1",
+			v2:       "1.0",
+			expected: true,
+		},
+		{
+			name:     "1.0 > 1.0_rc1 (release > rc)",
+			v1:       "1.0",
+			v2:       "1.0_rc1",
+			expected: true,
 		},
 	}
 
@@ -426,6 +740,12 @@ func TestVersion_IsLessThan(t *testing.T) {
 			v1:       "1.0.0",
 			v2:       "1.0.0",
 			expected: false,
+		},
+		{
+			name:     "1.0_rc1 < 1.0_p1 (rc < patchlevel)",
+			v1:       "1.0_rc1",
+			v2:       "1.0_p1",
+			expected: true,
 		},
 	}
 
@@ -547,6 +867,50 @@ func TestVersion_Immutability(t *testing.T) {
 	}
 }
 
+// TestVersionConstraint_Satisfies_PMS tests the Satisfies method with PMS-compliant versions
+func TestVersionConstraint_Satisfies_PMS(t *testing.T) {
+	tests := []struct {
+		name       string
+		constraint string
+		version    string
+		expected   bool
+	}{
+		// Basic version constraints
+		{"exact match", "1.0", "1.0", true},
+		{"exact no match", "1.0", "1.1", false},
+		{"greater equal pass", ">=1.0", "1.1", true},
+		{"greater equal exact", ">=1.0", "1.0", true},
+		{"greater equal fail", ">=1.0", "0.9", false},
+
+		// PMS suffix ordering in constraints
+		{"rc satisfies >= alpha", ">=1.0_alpha", "1.0_rc1", true},
+		{"p satisfies >= rc", ">=1.0_rc1", "1.0_p1", true},
+		{"alpha does not satisfy >= rc", ">=1.0_rc1", "1.0_alpha1", false},
+		{"release satisfies >= rc", ">=1.0_rc1", "1.0", true},
+		{"rc does not satisfy >= release", ">=1.0", "1.0_rc1", false},
+
+		// Letter suffix in constraints
+		{"1.0b satisfies >= 1.0a", ">=1.0a", "1.0b", true},
+		{"1.0 satisfies >= 1.0z", ">=1.0z", "1.0", true},
+		{"1.0a does not satisfy >= 1.0", ">=1.0", "1.0a", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vc, err := ParseVersionConstraint(tt.constraint)
+			if err != nil {
+				t.Fatalf("ParseVersionConstraint(%q) error: %v", tt.constraint, err)
+			}
+
+			result := vc.Satisfies(tt.version)
+			if result != tt.expected {
+				t.Errorf("VersionConstraint(%q).Satisfies(%q) = %v, expected %v",
+					tt.constraint, tt.version, result, tt.expected)
+			}
+		})
+	}
+}
+
 // BenchmarkNewVersion benchmarks version creation
 func BenchmarkNewVersion(b *testing.B) {
 	for i := 0; i < b.N; i++ {
@@ -562,5 +926,13 @@ func BenchmarkVersionCompareTo(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = v1.CompareTo(v2)
+	}
+}
+
+// BenchmarkCompareVersions_PMS benchmarks the direct comparison function
+func BenchmarkCompareVersions_PMS(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = CompareVersions("1.2.3_alpha4-r5", "1.2.3_beta1-r3")
 	}
 }


### PR DESCRIPTION
## Summary

Critical bug fixes for version comparison per PMS Chapter 3.2-3.3:

- **Fix suffix ordering** - Implemented PMS Algorithm 3.5-3.6:
  - Correct: `_alpha < _beta < _pre < _rc < (release) < _p`
  - Previously: Used alphabetical comparison (`_p < _pre < _rc`)
  - **Impact**: Fixes incorrect package version selection during dependency resolution

- **Fix leading zero handling** - Implemented PMS Algorithm 3.3

- **Fix letter suffix parsing** - `1.0a < 1.0b < 1.0z < 1.0`

- **Fix revision handling** - `-r0` now equals no revision

## Changes

| File | Changes |
|------|---------|
| `internal/pkg/version.go` | +280 lines - PMS-compliant Version struct |
| `internal/pkg/version_test.go` | +380 lines - comprehensive PMS tests |
| `internal/pkg/constraint.go` | +30 lines - uses new comparison |
| `CHANGELOG.md` | Added v0.2.1 section |
| `README.md` | Updated version |

## Test plan

- [x] All existing tests pass
- [x] 30+ new PMS compliance tests added
- [x] golangci-lint: 0 issues
- [x] gofmt: clean

## PMS References

- [Chapter 3.2-3.3: Version Comparison](docs/pms/chapter3-names-versions.md)
- [Algorithm 3.5-3.6: Suffix Ordering](docs/pms/chapter3-names-versions.md)