### PR TITLE
fix(ebuild): deterministic ABI lookup in multilib functions (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.1] - 2026-01-10
+
+### Hotfix: Multilib ABI Lookup
+
+#### Fixed
+- **Deterministic ABI lookup** - Fixed non-deterministic map iteration in multilib functions
+  - `computeABILibdir`, `GetABIChost`, `GetABICflags`, `GetABILdflags`, `setupABIEnvironment`
+  - Added `getCurrentArch()` to determine system architecture from CHOST
+  - Now uses deterministic search order as fallback
+  - Fixes CI test failures on Linux (TestComputeLibdir_WithABI, TestGetABICflags)
+
+---
+
 ## [0.5.0] - 2026-01-10
 
 ### Language Ecosystems Release
@@ -506,7 +519,8 @@ GRPM (Go Resource Package Manager) is a modern reimplementation of Gentoo's Port
 - **Issues**: https://github.com/grpmsoft/grpm/issues
 - **License**: [Apache-2.0](LICENSE)
 
-[Unreleased]: https://github.com/grpmsoft/grpm/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/grpmsoft/grpm/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/grpmsoft/grpm/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/grpmsoft/grpm/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/grpmsoft/grpm/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/grpmsoft/grpm/compare/v0.2.1...v0.3.0

--- a/internal/ebuild/eclass_multilib.go
+++ b/internal/ebuild/eclass_multilib.go
@@ -127,11 +127,26 @@ func (h *Helpers) computeABILibdir(abi string) string {
 		return libdir
 	}
 
-	// Look up in common ABIs
-	for _, abis := range CommonABIs {
+	// Determine current architecture from CHOST or DEFAULT_ABI
+	currentArch := h.getCurrentArch()
+
+	// First, look in the current architecture's ABIs
+	if abis, ok := CommonABIs[currentArch]; ok {
 		for _, a := range abis {
 			if a.Name == abi {
 				return a.LibDir
+			}
+		}
+	}
+
+	// Fallback: search in deterministic order (amd64 first for multilib cases)
+	archOrder := []string{"amd64", "arm64", "ppc64", "x86", "arm"}
+	for _, arch := range archOrder {
+		if abis, ok := CommonABIs[arch]; ok {
+			for _, a := range abis {
+				if a.Name == abi {
+					return a.LibDir
+				}
 			}
 		}
 	}
@@ -167,12 +182,28 @@ func (h *Helpers) GetABIChost(args []string) error {
 		return nil
 	}
 
-	// Look up in common ABIs
-	for _, abis := range CommonABIs {
+	// Determine current architecture from CHOST or DEFAULT_ABI
+	currentArch := h.getCurrentArch()
+
+	// First, look in the current architecture's ABIs
+	if abis, ok := CommonABIs[currentArch]; ok {
 		for _, a := range abis {
 			if a.Name == abi {
 				h.writeStdout(a.CHost)
 				return nil
+			}
+		}
+	}
+
+	// Fallback: search in deterministic order (amd64 first for multilib cases)
+	archOrder := []string{"amd64", "arm64", "ppc64", "x86", "arm"}
+	for _, arch := range archOrder {
+		if abis, ok := CommonABIs[arch]; ok {
+			for _, a := range abis {
+				if a.Name == abi {
+					h.writeStdout(a.CHost)
+					return nil
+				}
 			}
 		}
 	}
@@ -199,12 +230,28 @@ func (h *Helpers) GetABICflags(args []string) error {
 		return nil
 	}
 
-	// Look up in common ABIs
-	for _, abis := range CommonABIs {
+	// Determine current architecture from CHOST or DEFAULT_ABI
+	currentArch := h.getCurrentArch()
+
+	// First, look in the current architecture's ABIs
+	if abis, ok := CommonABIs[currentArch]; ok {
 		for _, a := range abis {
 			if a.Name == abi {
 				h.writeStdout(a.CFlags)
 				return nil
+			}
+		}
+	}
+
+	// Fallback: search in deterministic order (amd64 first for multilib cases)
+	archOrder := []string{"amd64", "arm64", "ppc64", "x86", "arm"}
+	for _, arch := range archOrder {
+		if abis, ok := CommonABIs[arch]; ok {
+			for _, a := range abis {
+				if a.Name == abi {
+					h.writeStdout(a.CFlags)
+					return nil
+				}
 			}
 		}
 	}
@@ -230,8 +277,11 @@ func (h *Helpers) GetABILdflags(args []string) error {
 		return nil
 	}
 
-	// Look up in common ABIs
-	for _, abis := range CommonABIs {
+	// Determine current architecture from CHOST or DEFAULT_ABI
+	currentArch := h.getCurrentArch()
+
+	// First, look in the current architecture's ABIs
+	if abis, ok := CommonABIs[currentArch]; ok {
 		for _, a := range abis {
 			if a.Name == abi {
 				h.writeStdout(a.LDFlags)
@@ -240,8 +290,59 @@ func (h *Helpers) GetABILdflags(args []string) error {
 		}
 	}
 
+	// Fallback: search in deterministic order (amd64 first for multilib cases)
+	archOrder := []string{"amd64", "arm64", "ppc64", "x86", "arm"}
+	for _, arch := range archOrder {
+		if abis, ok := CommonABIs[arch]; ok {
+			for _, a := range abis {
+				if a.Name == abi {
+					h.writeStdout(a.LDFlags)
+					return nil
+				}
+			}
+		}
+	}
+
 	h.writeStdout("")
 	return nil
+}
+
+// getCurrentArch determines the current system architecture from CHOST.
+func (h *Helpers) getCurrentArch() string {
+	// Check DEFAULT_ABI first
+	if defaultABI := h.getEnvOrDefault("DEFAULT_ABI", ""); defaultABI != "" {
+		// Map ABI to architecture
+		switch defaultABI {
+		case "amd64":
+			return "amd64"
+		case "x86":
+			return "x86"
+		case "arm64":
+			return "arm64"
+		case "arm":
+			return "arm"
+		case "ppc64":
+			return "ppc64"
+		}
+	}
+
+	// Determine from CHOST
+	chost := h.getEnvOrDefault("CHOST", "")
+	switch {
+	case strings.Contains(chost, "x86_64"):
+		return "amd64"
+	case strings.Contains(chost, "i686"), strings.Contains(chost, "i386"):
+		return "x86"
+	case strings.Contains(chost, "aarch64"):
+		return "arm64"
+	case strings.Contains(chost, "armv7"):
+		return "arm"
+	case strings.Contains(chost, "powerpc64"):
+		return "ppc64"
+	default:
+		// Default to amd64 for multilib support
+		return "amd64"
+	}
 }
 
 // MultilibEnv sets up the environment for a specific ABI.
@@ -260,12 +361,35 @@ func (h *Helpers) MultilibEnv(args []string) error {
 
 // setupABIEnvironment configures environment for a specific ABI.
 func (h *Helpers) setupABIEnvironment(abiName string) error {
-	// Find ABI definition
+	// Determine current architecture from CHOST or DEFAULT_ABI
+	currentArch := h.getCurrentArch()
+
+	// Find ABI definition - first in current arch, then deterministic order
 	var abi *ABI
-	for _, abis := range CommonABIs {
+
+	// First, look in the current architecture's ABIs
+	if abis, ok := CommonABIs[currentArch]; ok {
 		for i := range abis {
 			if abis[i].Name == abiName {
 				abi = &abis[i]
+				break
+			}
+		}
+	}
+
+	// Fallback: search in deterministic order
+	if abi == nil {
+		archOrder := []string{"amd64", "arm64", "ppc64", "x86", "arm"}
+		for _, arch := range archOrder {
+			if abis, ok := CommonABIs[arch]; ok {
+				for i := range abis {
+					if abis[i].Name == abiName {
+						abi = &abis[i]
+						break
+					}
+				}
+			}
+			if abi != nil {
 				break
 			}
 		}


### PR DESCRIPTION
## Summary

Hotfix for v0.5.0 release — fixes CI test failures on Linux.

### Problem
Non-deterministic Go map iteration order in multilib ABI functions caused different behavior on different platforms:
- **Windows**: Tests pass (happens to iterate in "correct" order)
- **Linux CI**: Tests fail (`TestComputeLibdir_WithABI`, `TestGetABICflags`)

### Root Cause
`CommonABIs` map contains `x86` ABI in two contexts:
- `CommonABIs["x86"]`: Native x86 (no `-m32` flag)
- `CommonABIs["amd64"]`: Multilib x86 (with `-m32` flag)

When looking up `x86` ABI, the non-deterministic iteration could find either entry first.

### Fix
1. Added `getCurrentArch()` to determine system architecture from `CHOST`
2. Now searches current architecture's ABIs first
3. Falls back to deterministic order: `amd64`, `arm64`, `ppc64`, `x86`, `arm`

### Affected Functions
- `computeABILibdir`
- `GetABIChost`
- `GetABICflags`
- `GetABILdflags`
- `setupABIEnvironment`

## Test Plan
- [x] Local tests pass on Windows
- [ ] CI tests pass on Linux (this PR)
- [x] No regressions in other ebuild tests