### PR TITLE
refactor(eclass): implement dynamic eclass loading (v0.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.2] - 2026-01-10
+
+### Refactor: Dynamic Eclass Loading
+
+> **Community Feedback Addressed**
+>
+> This release addresses criticism from the Gentoo community (forums.gentoo.org)
+> about hardcoded eclass implementations. Eclasses are now loaded dynamically
+> from the repository, matching Portage's behavior.
+
+#### Added
+- **Dynamic eclass loading** - Eclasses are now loaded from repository eclass/ directories
+  - New `internal/eclass/` package (3300+ lines) for dynamic loading
+  - `eclass.Cache` - Scans and caches eclass files with mtime tracking
+  - `eclass.Executor` - Executes eclasses via mvdan.cc/sh interpreter
+  - `eclass.HybridLoader` - Dynamic loading with Go fallbacks
+  - `ebuild.DynamicEclassLoader` - Bridge for integration
+  - `ebuild.SetupDynamicEclassLoading()` - Configuration helper
+
+- **Metadata accumulation** - Proper handling of DEPEND, IUSE, RDEPEND from eclasses
+  - Backup/restore of metadata variables during inherit
+  - E_DEPEND, E_IUSE accumulator variables
+
+- **EXPORT_FUNCTIONS support** - Phase function exports from eclasses
+
+#### Changed
+- `Executor` now uses dynamic eclass loading by default (`EnableDynamicEclass: true`)
+- Go eclass implementations (cmake, meson, python, cargo, etc.) serve as fallbacks
+- Added `EclassLocations` option for custom eclass search paths
+
+#### Technical Details
+- Uses mvdan.cc/sh bash interpreter for eclass execution
+- Priority: dynamic loading → Go fallbacks
+- Thread-safe with mutex protection
+- Non-fatal fallback on cache creation errors
+
+---
+
 ## [0.5.1] - 2026-01-10
 
 ### Hotfix: Multilib ABI Lookup

--- a/internal/ebuild/eclass.go
+++ b/internal/ebuild/eclass.go
@@ -17,6 +17,16 @@ import (
 	"mvdan.cc/sh/v3/syntax"
 )
 
+// EclassLoaderIface defines the interface for eclass loading.
+//
+// This interface allows different implementations:
+//   - EclassLoader: The original implementation that executes eclasses through the interpreter
+//   - DynamicEclassLoader: Uses the eclass package for dynamic loading with fallbacks
+type EclassLoaderIface interface {
+	// Inherit loads one or more eclasses.
+	Inherit(ctx context.Context, eclasses []string) error
+}
+
 // EclassRegistry manages loaded eclasses and their functions.
 //
 // The registry tracks which eclasses have been inherited to prevent

--- a/internal/ebuild/eclass_bridge.go
+++ b/internal/ebuild/eclass_bridge.go
@@ -1,0 +1,251 @@
+// Package ebuild implements ebuild execution engine.
+//
+// This file provides a bridge between the ebuild package and the new
+// eclass package, enabling dynamic eclass loading while maintaining
+// backward compatibility with existing Go implementations.
+package ebuild
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/grpmsoft/grpm/internal/eclass"
+	"mvdan.cc/sh/v3/interp"
+)
+
+// DynamicEclassLoader provides dynamic eclass loading using the eclass package.
+//
+// It wraps the eclass.HybridLoader and adapts it to the existing
+// EclassLoader interface used by the Helpers type.
+type DynamicEclassLoader struct {
+	// hybridLoader is the underlying hybrid loader.
+	hybridLoader *eclass.HybridLoader
+
+	// registry is the eclass registry for compatibility.
+	registry *EclassRegistry
+
+	// stdout and stderr for output.
+	stdout io.Writer
+	stderr io.Writer
+
+	// goImpls stores registered Go eclass implementations.
+	goImpls map[string]*GoEclassAdapter
+}
+
+// GoEclassAdapter adapts existing Go eclass implementations to the
+// eclass.GoEclassImpl interface.
+type GoEclassAdapter struct {
+	name           string
+	executeFunc    func(ctx context.Context, env map[string]string) error
+	hasPhaseFunc   func(phase string) bool
+	executePhase   func(ctx context.Context, phase string, env map[string]string) error
+	phaseFunctions map[string]func(ctx context.Context, env map[string]string) error
+}
+
+// Name returns the eclass name.
+func (a *GoEclassAdapter) Name() string {
+	return a.name
+}
+
+// Execute runs the eclass setup.
+func (a *GoEclassAdapter) Execute(ctx context.Context, env map[string]string) error {
+	if a.executeFunc != nil {
+		return a.executeFunc(ctx, env)
+	}
+	return nil
+}
+
+// HasPhaseFunction checks if the eclass provides a phase function.
+func (a *GoEclassAdapter) HasPhaseFunction(phase string) bool {
+	if a.hasPhaseFunc != nil {
+		return a.hasPhaseFunc(phase)
+	}
+	_, ok := a.phaseFunctions[phase]
+	return ok
+}
+
+// ExecutePhase runs a phase function.
+func (a *GoEclassAdapter) ExecutePhase(ctx context.Context, phase string, env map[string]string) error {
+	if a.executePhase != nil {
+		return a.executePhase(ctx, phase, env)
+	}
+	if fn, ok := a.phaseFunctions[phase]; ok {
+		return fn(ctx, env)
+	}
+	return fmt.Errorf("phase %s not provided by %s", phase, a.name)
+}
+
+// NewDynamicEclassLoader creates a new dynamic eclass loader.
+//
+// Parameters:
+//   - cache: The eclass cache for file lookup
+//   - execHandler: The exec handler for Go helper functions
+//   - stdout, stderr: Output writers
+func NewDynamicEclassLoader(
+	cache *eclass.Cache,
+	execHandler interp.ExecHandlerFunc,
+	stdout, stderr io.Writer,
+) *DynamicEclassLoader {
+	loader := &DynamicEclassLoader{
+		stdout:  stdout,
+		stderr:  stderr,
+		goImpls: make(map[string]*GoEclassAdapter),
+	}
+
+	// Create hybrid loader with the exec handler
+	loaderOpts := []eclass.HybridLoaderOption{
+		eclass.WithHybridOutput(stdout, stderr),
+	}
+
+	loader.hybridLoader = eclass.NewHybridLoader(cache, execHandler, loaderOpts...)
+
+	// Create registry from cache locations
+	portdir := ""
+	if locs := cache.Locations(); len(locs) > 0 {
+		portdir = locs[0]
+	}
+	loader.registry = NewEclassRegistry(portdir)
+
+	return loader
+}
+
+// Inherit loads one or more eclasses.
+//
+// This implements the same interface as EclassLoader.Inherit for compatibility.
+func (l *DynamicEclassLoader) Inherit(ctx context.Context, eclasses []string) error {
+	for _, name := range eclasses {
+		// Check if already loaded
+		if l.registry.IsLoaded(name) {
+			l.writeStdout(fmt.Sprintf(">>> Eclass %s already inherited (skipping)\n", name))
+			continue
+		}
+
+		// Try dynamic loading via hybrid loader
+		if err := l.hybridLoader.Inherit(ctx, []string{name}); err != nil {
+			return fmt.Errorf("inheriting %s: %w", name, err)
+		}
+
+		// Mark as loaded in registry
+		if ec, err := l.hybridLoader.GetCache().Get(name); err == nil {
+			l.registry.MarkLoaded(name, ec.Path)
+		}
+	}
+
+	return nil
+}
+
+// RegisterGoEclass registers a Go eclass implementation as fallback.
+//
+// This allows existing Go implementations (cmake, meson, etc.) to be
+// used as fallbacks when dynamic execution fails.
+func (l *DynamicEclassLoader) RegisterGoEclass(adapter *GoEclassAdapter) {
+	l.goImpls[adapter.name] = adapter
+
+	// Also register with hybrid loader
+	l.hybridLoader = eclass.NewHybridLoader(
+		l.hybridLoader.GetCache(),
+		nil,
+		eclass.WithGoFallback(adapter),
+		eclass.WithHybridOutput(l.stdout, l.stderr),
+	)
+}
+
+// GetExecutor returns the underlying eclass executor.
+func (l *DynamicEclassLoader) GetExecutor() *eclass.Executor {
+	return l.hybridLoader.GetExecutor()
+}
+
+// GetCache returns the eclass cache.
+func (l *DynamicEclassLoader) GetCache() *eclass.Cache {
+	return l.hybridLoader.GetCache()
+}
+
+// GetRegistry returns the eclass registry for compatibility.
+func (l *DynamicEclassLoader) GetRegistry() *EclassRegistry {
+	return l.registry
+}
+
+// GetInherited returns the INHERITED variable value.
+func (l *DynamicEclassLoader) GetInherited() string {
+	return l.registry.GetInherited()
+}
+
+// GetExportedFunction returns the eclass that exports a phase function.
+func (l *DynamicEclassLoader) GetExportedFunction(phase string) (string, bool) {
+	return l.hybridLoader.GetExecutor().GetExportedFunction(phase)
+}
+
+// GetAccumulatedMetadata returns accumulated metadata from eclasses.
+func (l *DynamicEclassLoader) GetAccumulatedMetadata() map[string]string {
+	return l.hybridLoader.GetExecutor().GetAccumulatedMetadata()
+}
+
+// FinalizeMetadata merges accumulated metadata into the environment.
+func (l *DynamicEclassLoader) FinalizeMetadata() {
+	l.hybridLoader.GetExecutor().FinalizeMetadata()
+}
+
+func (l *DynamicEclassLoader) writeStdout(s string) {
+	if l.stdout != nil {
+		_, _ = io.WriteString(l.stdout, s)
+	}
+}
+
+// CreateEclassCache creates an eclass cache for the given repository paths.
+//
+// This is a convenience function for setting up dynamic eclass loading.
+func CreateEclassCache(repoPaths []string) (*eclass.Cache, error) {
+	locations := make([]string, 0, len(repoPaths))
+	for _, path := range repoPaths {
+		locations = append(locations, path+"/eclass")
+	}
+	return eclass.NewCacheWithLocations(locations)
+}
+
+// CreateDefaultEclassCache creates an eclass cache with default Gentoo locations.
+func CreateDefaultEclassCache() (*eclass.Cache, error) {
+	return eclass.NewCacheWithLocations(eclass.DefaultLocations())
+}
+
+// SetupDynamicEclassLoading configures the interpreter for dynamic eclass loading.
+//
+// This replaces the default EclassLoader with a DynamicEclassLoader.
+//
+// Parameters:
+//   - interp: The interpreter to configure
+//   - cache: The eclass cache (or nil to use defaults)
+//
+// Returns the configured DynamicEclassLoader for further customization.
+func SetupDynamicEclassLoading(interp *Interpreter, cache *eclass.Cache) (*DynamicEclassLoader, error) {
+	if cache == nil {
+		var err error
+		cache, err = CreateDefaultEclassCache()
+		if err != nil {
+			return nil, fmt.Errorf("creating default cache: %w", err)
+		}
+	}
+
+	// Create exec handler that uses interpreter's helpers
+	// This allows eclass code to call Go helper functions
+	execHandler := func(ctx context.Context, args []string) error {
+		if len(args) == 0 {
+			return nil
+		}
+
+		cmd := args[0]
+		cmdArgs := args[1:]
+
+		// Dispatch to interpreter's command map
+		return interp.dispatchCommand(cmd, cmdArgs)
+	}
+
+	// Create dynamic loader
+	loader := NewDynamicEclassLoader(cache, execHandler, interp.stdout, interp.stderr)
+
+	// Replace the default eclass loader
+	// DynamicEclassLoader implements EclassLoaderIface directly
+	interp.helpers.SetEclassLoader(loader)
+
+	return loader, nil
+}

--- a/internal/ebuild/executor.go
+++ b/internal/ebuild/executor.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/grpmsoft/grpm/internal/eclass"
 	"github.com/grpmsoft/grpm/internal/fetch"
 	"github.com/grpmsoft/grpm/internal/pkg"
 	"github.com/grpmsoft/grpm/internal/sandbox"
@@ -75,6 +76,16 @@ type Executor struct {
 	// interpreter is the bash interpreter for executing ebuild functions
 	interpreter *Interpreter
 
+	// dynamicLoader provides dynamic eclass loading from repository
+	// Uses HybridLoader with Go fallbacks for complex eclasses
+	dynamicLoader *DynamicEclassLoader
+
+	// eclassCache stores the eclass file cache for dynamic loading
+	eclassCache *eclass.Cache
+
+	// enableDynamicEclass tracks if dynamic loading is enabled
+	enableDynamicEclass bool
+
 	// currentPhase tracks the currently executing phase for EBUILD_PHASE
 	currentPhase Phase
 }
@@ -113,18 +124,29 @@ type ExecutorOptions struct {
 	// DenyNetwork blocks network access during build.
 	// Implements Portage's network-sandbox feature.
 	DenyNetwork bool
+
+	// EnableDynamicEclass enables dynamic eclass loading from repository.
+	// When true (default), eclasses are loaded directly from eclass/ directories
+	// using mvdan.cc/sh interpreter, with fallback to Go implementations.
+	// This addresses the community feedback about hardcoded eclasses.
+	EnableDynamicEclass bool
+
+	// EclassLocations specifies custom eclass search paths.
+	// If empty, defaults to [PortDir/eclass, /var/db/repos/gentoo/eclass].
+	EclassLocations []string
 }
 
 // DefaultOptions returns default executor options.
 func DefaultOptions() ExecutorOptions {
 	return ExecutorOptions{
-		TmpDir:        "/var/tmp/portage",
-		PortDir:       "/var/db/repos/gentoo",
-		DistDir:       "/var/cache/distfiles",
-		EnableSandbox: true,
-		EnableTests:   false,
-		KeepWork:      false,
-		DenyNetwork:   true, // network-sandbox by default
+		TmpDir:              "/var/tmp/portage",
+		PortDir:             "/var/db/repos/gentoo",
+		DistDir:             "/var/cache/distfiles",
+		EnableSandbox:       true,
+		EnableTests:         false,
+		KeepWork:            false,
+		DenyNetwork:         true,  // network-sandbox by default
+		EnableDynamicEclass: true,  // dynamic eclass loading by default
 	}
 }
 
@@ -177,6 +199,27 @@ func NewExecutor(pkg *pkg.Package, opts ExecutorOptions) (*Executor, error) {
 
 		executor.Sandbox = sb
 		executor.SandboxConfig = sbConfig
+	}
+
+	// Initialize dynamic eclass loading if enabled
+	if opts.EnableDynamicEclass {
+		executor.enableDynamicEclass = true
+
+		locations := opts.EclassLocations
+		if len(locations) == 0 {
+			// Default locations: PortDir/eclass and standard Gentoo path
+			locations = []string{
+				filepath.Join(opts.PortDir, "eclass"),
+			}
+		}
+
+		cache, err := eclass.NewCacheWithLocations(locations)
+		if err != nil {
+			// Non-fatal: fall back to Go implementations
+			log.Printf("[ebuild] warning: failed to create eclass cache: %v (using Go fallbacks)", err)
+		} else {
+			executor.eclassCache = cache
+		}
 	}
 
 	return executor, nil
@@ -685,6 +728,20 @@ func (e *Executor) RunPhaseFunction(phase Phase) (string, error) {
 // initInterpreter initializes the bash interpreter for the executor.
 func (e *Executor) initInterpreter() error {
 	e.interpreter = NewInterpreter(e.Env, os.Stdout, os.Stderr)
+
+	// Setup dynamic eclass loading if cache is available
+	if e.enableDynamicEclass && e.eclassCache != nil {
+		loader, err := SetupDynamicEclassLoading(e.interpreter, e.eclassCache)
+		if err != nil {
+			// Non-fatal: fall back to Go implementations
+			log.Printf("[ebuild] warning: failed to setup dynamic eclass loading: %v", err)
+		} else {
+			e.dynamicLoader = loader
+			log.Printf("[ebuild] dynamic eclass loading enabled (%d locations)",
+				len(e.eclassCache.Locations()))
+		}
+	}
+
 	return nil
 }
 

--- a/internal/ebuild/helpers.go
+++ b/internal/ebuild/helpers.go
@@ -64,12 +64,12 @@ type Helpers struct {
 	libDir      string // LIBDIR - library directory name (lib, lib64)
 
 	// Eclass support
-	eclassRegistry *EclassRegistry // Eclass registry for inherit tracking
-	eclassLoader   *EclassLoader   // Eclass loader for inherit functionality
-	eclassStack    *EclassStack    // Stack for eshopts/estack operations
-	cflags         []string        // CFLAGS for flag-o-matic
-	cxxflags       []string        // CXXFLAGS for flag-o-matic
-	ldflags        []string        // LDFLAGS for flag-o-matic
+	eclassRegistry *EclassRegistry   // Eclass registry for inherit tracking
+	eclassLoader   EclassLoaderIface // Eclass loader for inherit functionality (interface)
+	eclassStack    *EclassStack      // Stack for eshopts/estack operations
+	cflags         []string          // CFLAGS for flag-o-matic
+	cxxflags       []string          // CXXFLAGS for flag-o-matic
+	ldflags        []string          // LDFLAGS for flag-o-matic
 
 	// Package database for has_version/best_version queries
 	pkgDB *state.PackageDatabase
@@ -132,14 +132,17 @@ func (h *Helpers) SetPackageDatabase(db *state.PackageDatabase) {
 // This must be called after creating both Helpers and Interpreter to resolve
 // the circular dependency between them. The EclassLoader uses the Interpreter
 // to execute eclass bash code.
-func (h *Helpers) SetEclassLoader(loader *EclassLoader) {
+//
+// The loader can be either a *EclassLoader (legacy) or any type implementing
+// EclassLoaderIface (for dynamic loading).
+func (h *Helpers) SetEclassLoader(loader EclassLoaderIface) {
 	h.eclassLoader = loader
 }
 
-// GetEclassLoader returns the eclass loader, creating one if needed.
+// GetEclassLoader returns the eclass loader.
 //
-// Returns nil if no interpreter is available to create a loader.
-func (h *Helpers) GetEclassLoader() *EclassLoader {
+// Returns nil if no loader is set.
+func (h *Helpers) GetEclassLoader() EclassLoaderIface {
 	return h.eclassLoader
 }
 

--- a/internal/eclass/cache.go
+++ b/internal/eclass/cache.go
@@ -1,0 +1,478 @@
+// Package eclass provides dynamic eclass loading and execution.
+//
+// This package implements the eclass cache and executor for GRPM,
+// replacing hardcoded Go eclass implementations with dynamic loading
+// from repository eclass/ directories. This approach ensures:
+//   - Gentoo eclass updates propagate to GRPM automatically
+//   - Custom overlay eclasses work correctly
+//   - Different repositories can have different eclass versions
+//
+// Reference: Portage lib/portage/eclass_cache.py
+package eclass
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Eclass represents a cached eclass file.
+//
+// This is a value object that is immutable after creation.
+// It stores metadata about an eclass file for caching and validation.
+type Eclass struct {
+	// Name is the eclass name without .eclass extension.
+	Name string
+
+	// Path is the full filesystem path to the .eclass file.
+	Path string
+
+	// EclassDir is the directory containing this eclass (e.g., /var/db/repos/gentoo/eclass).
+	EclassDir string
+
+	// Mtime is the modification time for cache invalidation.
+	Mtime time.Time
+
+	// Checksum is the SHA256 checksum for content verification.
+	Checksum string
+
+	// RepoName is the repository name this eclass belongs to.
+	RepoName string
+}
+
+// ID returns a unique identifier for this eclass.
+func (e *Eclass) ID() string {
+	return e.Name + "@" + e.RepoName
+}
+
+// Cache manages eclass discovery, caching, and retrieval.
+//
+// It scans eclass/ directories in repositories and maintains a cache
+// with mtime-based invalidation. The cache follows Portage's priority
+// ordering: masters -> repo -> overrides.
+//
+// Thread-safe: All methods can be called concurrently.
+type Cache struct {
+	mu sync.RWMutex
+
+	// eclasses maps eclass name to the resolved eclass entry.
+	// When multiple repos define the same eclass, the highest-priority one wins.
+	eclasses map[string]*Eclass
+
+	// locations stores eclass directories in priority order (lowest to highest).
+	// Later entries override earlier ones.
+	locations []string
+
+	// repoNames maps eclass directory path to repository name.
+	repoNames map[string]string
+
+	// masterEclassDir is the master (gentoo) eclass directory for deduplication.
+	masterEclassDir string
+
+	// masterEclasses stores mtime of master eclasses for identical-eclass detection.
+	masterEclasses map[string]time.Time
+}
+
+// NewCache creates a new empty eclass cache.
+func NewCache() *Cache {
+	return &Cache{
+		eclasses:       make(map[string]*Eclass),
+		locations:      make([]string, 0),
+		repoNames:      make(map[string]string),
+		masterEclasses: make(map[string]time.Time),
+	}
+}
+
+// NewCacheWithLocations creates a cache and scans the specified eclass directories.
+//
+// Locations are processed in order; later locations override earlier ones.
+// This matches Portage behavior where overlays override the main repo.
+func NewCacheWithLocations(locations []string) (*Cache, error) {
+	c := NewCache()
+	if err := c.AddLocations(locations); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// AddLocations adds eclass directories to the cache.
+//
+// Directories are scanned immediately and eclasses are added to the cache.
+// Later locations override earlier ones (overlay behavior).
+func (c *Cache) AddLocations(locations []string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, loc := range locations {
+		// Normalize path
+		loc = filepath.Clean(loc)
+
+		// Skip if already added
+		alreadyAdded := false
+		for _, existing := range c.locations {
+			if existing == loc {
+				alreadyAdded = true
+				break
+			}
+		}
+		if alreadyAdded {
+			continue
+		}
+
+		c.locations = append(c.locations, loc)
+
+		// Scan the directory
+		if err := c.scanDirectoryLocked(loc); err != nil {
+			// Log warning but continue - directory may not exist yet
+			continue
+		}
+	}
+
+	return nil
+}
+
+// AddRepoWithMasters adds a repository with its master repositories.
+//
+// Masters are added first (lower priority), then the repo itself (higher priority).
+// This matches Portage's masters inheritance model.
+//
+// Parameters:
+//   - repoName: Name of the repository (e.g., "gentoo", "guru")
+//   - repoPath: Path to the repository root (eclass/ will be appended)
+//   - masters: Paths to master repository roots (in order)
+func (c *Cache) AddRepoWithMasters(repoName string, repoPath string, masters []string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Add masters first (lower priority)
+	for _, master := range masters {
+		eclassDir := filepath.Join(master, "eclass")
+		if _, err := os.Stat(eclassDir); os.IsNotExist(err) {
+			continue
+		}
+
+		// Determine master repo name from path
+		masterName := filepath.Base(master)
+		c.repoNames[eclassDir] = masterName
+
+		// First master becomes the master eclass dir for deduplication
+		if c.masterEclassDir == "" {
+			c.masterEclassDir = eclassDir
+		}
+
+		if !c.hasLocation(eclassDir) {
+			c.locations = append(c.locations, eclassDir)
+			if err := c.scanDirectoryLocked(eclassDir); err != nil {
+				continue
+			}
+		}
+	}
+
+	// Add the repo itself (higher priority)
+	eclassDir := filepath.Join(repoPath, "eclass")
+	c.repoNames[eclassDir] = repoName
+
+	if _, err := os.Stat(eclassDir); err == nil {
+		if !c.hasLocation(eclassDir) {
+			c.locations = append(c.locations, eclassDir)
+			if err := c.scanDirectoryLocked(eclassDir); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// hasLocation checks if a location is already in the list.
+// Must be called with lock held.
+func (c *Cache) hasLocation(loc string) bool {
+	for _, existing := range c.locations {
+		if existing == loc {
+			return true
+		}
+	}
+	return false
+}
+
+// scanDirectoryLocked scans an eclass directory and adds entries to the cache.
+// Must be called with lock held.
+func (c *Cache) scanDirectoryLocked(eclassDir string) error {
+	entries, err := os.ReadDir(eclassDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // Not an error - directory may not exist
+		}
+		return fmt.Errorf("reading eclass directory %s: %w", eclassDir, err)
+	}
+
+	repoName := c.repoNames[eclassDir]
+	isMaster := eclassDir == c.masterEclassDir
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".eclass") {
+			continue
+		}
+
+		eclassName := strings.TrimSuffix(name, ".eclass")
+		eclassPath := filepath.Join(eclassDir, name)
+
+		info, err := entry.Info()
+		if err != nil {
+			continue // Skip files we can't stat
+		}
+		mtime := info.ModTime()
+
+		// If this is the master repo, record mtime for deduplication
+		if isMaster {
+			c.masterEclasses[eclassName] = mtime
+		} else if c.masterEclassDir != "" {
+			// Check if this eclass is identical to master (same mtime)
+			// If so, prefer the master entry
+			if masterMtime, ok := c.masterEclasses[eclassName]; ok {
+				if masterMtime.Equal(mtime) {
+					continue // Skip - identical to master
+				}
+			}
+		}
+
+		// Create eclass entry
+		eclass := &Eclass{
+			Name:      eclassName,
+			Path:      eclassPath,
+			EclassDir: eclassDir,
+			Mtime:     mtime,
+			RepoName:  repoName,
+		}
+
+		// Checksum is computed lazily on first access
+		c.eclasses[eclassName] = eclass
+	}
+
+	return nil
+}
+
+// Get retrieves an eclass by name.
+//
+// Returns the highest-priority eclass with the given name, or an error
+// if the eclass is not found.
+func (c *Cache) Get(name string) (*Eclass, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	eclass, ok := c.eclasses[name]
+	if !ok {
+		return nil, &EclassNotFoundError{Name: name, Locations: c.locations}
+	}
+
+	return eclass, nil
+}
+
+// GetWithChecksum retrieves an eclass and computes its checksum if not cached.
+//
+// This is more expensive than Get() but ensures checksum is populated.
+func (c *Cache) GetWithChecksum(name string) (*Eclass, error) {
+	c.mu.RLock()
+	eclass, ok := c.eclasses[name]
+	c.mu.RUnlock()
+
+	if !ok {
+		return nil, &EclassNotFoundError{Name: name, Locations: c.locations}
+	}
+
+	// Compute checksum if not cached
+	if eclass.Checksum == "" {
+		checksum, err := computeChecksum(eclass.Path)
+		if err != nil {
+			return nil, fmt.Errorf("computing checksum for %s: %w", name, err)
+		}
+
+		c.mu.Lock()
+		// Create new eclass with checksum (immutability)
+		updated := &Eclass{
+			Name:      eclass.Name,
+			Path:      eclass.Path,
+			EclassDir: eclass.EclassDir,
+			Mtime:     eclass.Mtime,
+			Checksum:  checksum,
+			RepoName:  eclass.RepoName,
+		}
+		c.eclasses[name] = updated
+		c.mu.Unlock()
+
+		return updated, nil
+	}
+
+	return eclass, nil
+}
+
+// Has checks if an eclass exists in the cache.
+func (c *Cache) Has(name string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	_, ok := c.eclasses[name]
+	return ok
+}
+
+// List returns all eclass names in the cache.
+func (c *Cache) List() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	names := make([]string, 0, len(c.eclasses))
+	for name := range c.eclasses {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Invalidate removes an eclass from the cache, forcing reload on next access.
+func (c *Cache) Invalidate(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.eclasses, name)
+}
+
+// InvalidateAll clears the entire cache.
+func (c *Cache) InvalidateAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.eclasses = make(map[string]*Eclass)
+	c.masterEclasses = make(map[string]time.Time)
+}
+
+// Refresh rescans all eclass directories and updates the cache.
+//
+// This detects new eclasses, removed eclasses, and modified eclasses
+// based on mtime changes.
+func (c *Cache) Refresh() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Clear existing entries
+	c.eclasses = make(map[string]*Eclass)
+	c.masterEclasses = make(map[string]time.Time)
+
+	// Rescan all locations
+	for _, loc := range c.locations {
+		if err := c.scanDirectoryLocked(loc); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ValidateEclass checks if a cached eclass is still valid.
+//
+// Returns true if the eclass file has the same mtime as cached.
+// This is used for incremental validation without re-scanning.
+func (c *Cache) ValidateEclass(name string) (bool, error) {
+	c.mu.RLock()
+	eclass, ok := c.eclasses[name]
+	c.mu.RUnlock()
+
+	if !ok {
+		return false, nil
+	}
+
+	info, err := os.Stat(eclass.Path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// File was removed - invalidate
+			c.Invalidate(name)
+			return false, nil
+		}
+		return false, err
+	}
+
+	return info.ModTime().Equal(eclass.Mtime), nil
+}
+
+// Locations returns the list of eclass directories in priority order.
+func (c *Cache) Locations() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	result := make([]string, len(c.locations))
+	copy(result, c.locations)
+	return result
+}
+
+// LocationsString returns locations as a space-separated string.
+//
+// This format is used by PORTAGE_ECLASS_LOCATIONS environment variable.
+func (c *Cache) LocationsString() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// Reverse order for bash consumption (highest priority first)
+	reversed := make([]string, len(c.locations))
+	for i, loc := range c.locations {
+		reversed[len(c.locations)-1-i] = loc
+	}
+	return strings.Join(reversed, " ")
+}
+
+// GetEclassData returns eclass data for the specified inherited eclasses.
+//
+// This is used for cache validation - returns a map of eclass name to Eclass.
+func (c *Cache) GetEclassData(inherits []string) (map[string]*Eclass, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	result := make(map[string]*Eclass, len(inherits))
+	for _, name := range inherits {
+		eclass, ok := c.eclasses[name]
+		if !ok {
+			return nil, &EclassNotFoundError{Name: name, Locations: c.locations}
+		}
+		result[name] = eclass
+	}
+	return result, nil
+}
+
+// computeChecksum calculates SHA256 checksum of a file.
+func computeChecksum(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// EclassNotFoundError is returned when an eclass cannot be found.
+type EclassNotFoundError struct {
+	Name      string
+	Locations []string
+}
+
+func (e *EclassNotFoundError) Error() string {
+	return fmt.Sprintf("eclass %s not found in: %v", e.Name, e.Locations)
+}
+
+// IsEclassNotFound checks if an error is an EclassNotFoundError.
+func IsEclassNotFound(err error) bool {
+	var eclassErr *EclassNotFoundError
+	return errors.As(err, &eclassErr)
+}

--- a/internal/eclass/cache_test.go
+++ b/internal/eclass/cache_test.go
@@ -1,0 +1,467 @@
+package eclass
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewCache(t *testing.T) {
+	c := NewCache()
+	if c == nil {
+		t.Fatal("NewCache returned nil")
+	}
+
+	if len(c.eclasses) != 0 {
+		t.Errorf("expected empty eclasses, got %d", len(c.eclasses))
+	}
+
+	if len(c.locations) != 0 {
+		t.Errorf("expected empty locations, got %d", len(c.locations))
+	}
+}
+
+func TestCacheScanDirectory(t *testing.T) {
+	// Create a temporary eclass directory
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatalf("failed to create eclass dir: %v", err)
+	}
+
+	// Create test eclass files
+	eclasses := []string{"test", "foo", "bar"}
+	for _, name := range eclasses {
+		content := "# Copyright 2025\n# " + name + ".eclass\n"
+		path := filepath.Join(eclassDir, name+".eclass")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to create eclass %s: %v", name, err)
+		}
+	}
+
+	// Create a non-eclass file (should be ignored)
+	if err := os.WriteFile(filepath.Join(eclassDir, "README.txt"), []byte("readme"), 0644); err != nil {
+		t.Fatalf("failed to create README: %v", err)
+	}
+
+	// Create cache and add location
+	c, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatalf("NewCacheWithLocations failed: %v", err)
+	}
+
+	// Verify all eclasses were found
+	for _, name := range eclasses {
+		if !c.Has(name) {
+			t.Errorf("eclass %s not found in cache", name)
+		}
+
+		eclass, err := c.Get(name)
+		if err != nil {
+			t.Errorf("Get(%s) failed: %v", name, err)
+			continue
+		}
+
+		if eclass.Name != name {
+			t.Errorf("expected name %s, got %s", name, eclass.Name)
+		}
+
+		expectedPath := filepath.Join(eclassDir, name+".eclass")
+		if eclass.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, eclass.Path)
+		}
+
+		if eclass.EclassDir != eclassDir {
+			t.Errorf("expected eclassDir %s, got %s", eclassDir, eclass.EclassDir)
+		}
+	}
+
+	// Verify list returns all eclasses
+	list := c.List()
+	if len(list) != len(eclasses) {
+		t.Errorf("expected %d eclasses in list, got %d", len(eclasses), len(list))
+	}
+}
+
+func TestCacheGetNotFound(t *testing.T) {
+	c := NewCache()
+
+	_, err := c.Get("nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent eclass")
+	}
+
+	if !IsEclassNotFound(err) {
+		t.Errorf("expected EclassNotFoundError, got %T", err)
+	}
+}
+
+func TestCacheOverlayPriority(t *testing.T) {
+	// Create two eclass directories simulating master + overlay
+	tmpDir := t.TempDir()
+
+	masterDir := filepath.Join(tmpDir, "gentoo", "eclass")
+	overlayDir := filepath.Join(tmpDir, "overlay", "eclass")
+
+	if err := os.MkdirAll(masterDir, 0755); err != nil {
+		t.Fatalf("failed to create master dir: %v", err)
+	}
+	if err := os.MkdirAll(overlayDir, 0755); err != nil {
+		t.Fatalf("failed to create overlay dir: %v", err)
+	}
+
+	// Create test.eclass in both directories
+	masterContent := "# master version\nECLASS_VERSION=master"
+	overlayContent := "# overlay version\nECLASS_VERSION=overlay"
+
+	// Write master first
+	masterPath := filepath.Join(masterDir, "test.eclass")
+	if err := os.WriteFile(masterPath, []byte(masterContent), 0644); err != nil {
+		t.Fatalf("failed to create master eclass: %v", err)
+	}
+
+	// Wait a bit and write overlay with different mtime
+	time.Sleep(10 * time.Millisecond)
+	overlayPath := filepath.Join(overlayDir, "test.eclass")
+	if err := os.WriteFile(overlayPath, []byte(overlayContent), 0644); err != nil {
+		t.Fatalf("failed to create overlay eclass: %v", err)
+	}
+
+	// Create cache with master first, then overlay (higher priority)
+	c, err := NewCacheWithLocations([]string{masterDir, overlayDir})
+	if err != nil {
+		t.Fatalf("NewCacheWithLocations failed: %v", err)
+	}
+
+	// Overlay should win
+	eclass, err := c.Get("test")
+	if err != nil {
+		t.Fatalf("Get(test) failed: %v", err)
+	}
+
+	if eclass.Path != overlayPath {
+		t.Errorf("expected overlay path %s, got %s", overlayPath, eclass.Path)
+	}
+}
+
+func TestCacheInvalidate(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatalf("failed to create eclass dir: %v", err)
+	}
+
+	path := filepath.Join(eclassDir, "test.eclass")
+	if err := os.WriteFile(path, []byte("# test"), 0644); err != nil {
+		t.Fatalf("failed to create eclass: %v", err)
+	}
+
+	c, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatalf("NewCacheWithLocations failed: %v", err)
+	}
+
+	// Verify eclass exists
+	if !c.Has("test") {
+		t.Error("expected test eclass to exist")
+	}
+
+	// Invalidate
+	c.Invalidate("test")
+
+	// Verify it's gone
+	if c.Has("test") {
+		t.Error("expected test eclass to be invalidated")
+	}
+}
+
+func TestCacheRefresh(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatalf("failed to create eclass dir: %v", err)
+	}
+
+	// Create initial eclass
+	path := filepath.Join(eclassDir, "test.eclass")
+	if err := os.WriteFile(path, []byte("# test v1"), 0644); err != nil {
+		t.Fatalf("failed to create eclass: %v", err)
+	}
+
+	c, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatalf("NewCacheWithLocations failed: %v", err)
+	}
+
+	initialList := c.List()
+	if len(initialList) != 1 {
+		t.Errorf("expected 1 eclass, got %d", len(initialList))
+	}
+
+	// Add a new eclass
+	path2 := filepath.Join(eclassDir, "new.eclass")
+	if err := os.WriteFile(path2, []byte("# new"), 0644); err != nil {
+		t.Fatalf("failed to create new eclass: %v", err)
+	}
+
+	// Refresh
+	if err := c.Refresh(); err != nil {
+		t.Fatalf("Refresh failed: %v", err)
+	}
+
+	// Verify new eclass is found
+	refreshedList := c.List()
+	if len(refreshedList) != 2 {
+		t.Errorf("expected 2 eclasses after refresh, got %d", len(refreshedList))
+	}
+
+	if !c.Has("new") {
+		t.Error("expected 'new' eclass after refresh")
+	}
+}
+
+func TestCacheGetWithChecksum(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatalf("failed to create eclass dir: %v", err)
+	}
+
+	content := "# test eclass content"
+	path := filepath.Join(eclassDir, "test.eclass")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to create eclass: %v", err)
+	}
+
+	c, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatalf("NewCacheWithLocations failed: %v", err)
+	}
+
+	// First Get - checksum not computed
+	eclass, err := c.Get("test")
+	if err != nil {
+		t.Fatalf("Get(test) failed: %v", err)
+	}
+	if eclass.Checksum != "" {
+		t.Errorf("expected empty checksum on Get, got %s", eclass.Checksum)
+	}
+
+	// GetWithChecksum - checksum computed
+	eclassWithSum, err := c.GetWithChecksum("test")
+	if err != nil {
+		t.Fatalf("GetWithChecksum(test) failed: %v", err)
+	}
+	if eclassWithSum.Checksum == "" {
+		t.Error("expected checksum to be computed")
+	}
+
+	// Subsequent Get should return cached checksum
+	eclassAgain, err := c.Get("test")
+	if err != nil {
+		t.Fatalf("Get(test) after checksum failed: %v", err)
+	}
+	if eclassAgain.Checksum != eclassWithSum.Checksum {
+		t.Errorf("checksum mismatch: %s vs %s", eclassAgain.Checksum, eclassWithSum.Checksum)
+	}
+}
+
+func TestCacheValidateEclass(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatalf("failed to create eclass dir: %v", err)
+	}
+
+	path := filepath.Join(eclassDir, "test.eclass")
+	if err := os.WriteFile(path, []byte("# test"), 0644); err != nil {
+		t.Fatalf("failed to create eclass: %v", err)
+	}
+
+	c, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatalf("NewCacheWithLocations failed: %v", err)
+	}
+
+	// Should be valid initially
+	valid, err := c.ValidateEclass("test")
+	if err != nil {
+		t.Fatalf("ValidateEclass failed: %v", err)
+	}
+	if !valid {
+		t.Error("expected eclass to be valid")
+	}
+
+	// Modify file
+	time.Sleep(10 * time.Millisecond) // Ensure mtime changes
+	if err := os.WriteFile(path, []byte("# modified"), 0644); err != nil {
+		t.Fatalf("failed to modify eclass: %v", err)
+	}
+
+	// Should now be invalid
+	valid, err = c.ValidateEclass("test")
+	if err != nil {
+		t.Fatalf("ValidateEclass after modification failed: %v", err)
+	}
+	if valid {
+		t.Error("expected eclass to be invalid after modification")
+	}
+}
+
+func TestCacheLocationsString(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dir1 := filepath.Join(tmpDir, "dir1")
+	dir2 := filepath.Join(tmpDir, "dir2")
+	if err := os.MkdirAll(dir1, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dir2, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := NewCacheWithLocations([]string{dir1, dir2})
+	if err != nil {
+		t.Fatalf("NewCacheWithLocations failed: %v", err)
+	}
+
+	locStr := c.LocationsString()
+
+	// Highest priority should come first in the string
+	// dir2 was added last, so it should be first in the output
+	if !contains(locStr, dir1) || !contains(locStr, dir2) {
+		t.Errorf("LocationsString missing dirs: %s", locStr)
+	}
+}
+
+func TestCacheAddRepoWithMasters(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create gentoo (master) repo structure
+	gentooRoot := filepath.Join(tmpDir, "gentoo")
+	gentooEclass := filepath.Join(gentooRoot, "eclass")
+	if err := os.MkdirAll(gentooEclass, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create overlay repo structure
+	overlayRoot := filepath.Join(tmpDir, "overlay")
+	overlayEclass := filepath.Join(overlayRoot, "eclass")
+	if err := os.MkdirAll(overlayEclass, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create master eclass
+	masterPath := filepath.Join(gentooEclass, "base.eclass")
+	if err := os.WriteFile(masterPath, []byte("# base from gentoo"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create overlay-specific eclass
+	overlayOnlyPath := filepath.Join(overlayEclass, "custom.eclass")
+	if err := os.WriteFile(overlayOnlyPath, []byte("# custom from overlay"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewCache()
+	err := c.AddRepoWithMasters("overlay", overlayRoot, []string{gentooRoot})
+	if err != nil {
+		t.Fatalf("AddRepoWithMasters failed: %v", err)
+	}
+
+	// Should have both eclasses
+	if !c.Has("base") {
+		t.Error("expected 'base' eclass from master")
+	}
+	if !c.Has("custom") {
+		t.Error("expected 'custom' eclass from overlay")
+	}
+
+	// Verify base comes from gentoo
+	base, err := c.Get("base")
+	if err != nil {
+		t.Fatalf("Get(base) failed: %v", err)
+	}
+	if base.Path != masterPath {
+		t.Errorf("expected base path %s, got %s", masterPath, base.Path)
+	}
+
+	// Verify custom comes from overlay
+	custom, err := c.Get("custom")
+	if err != nil {
+		t.Fatalf("Get(custom) failed: %v", err)
+	}
+	if custom.Path != overlayOnlyPath {
+		t.Errorf("expected custom path %s, got %s", overlayOnlyPath, custom.Path)
+	}
+}
+
+func TestCacheGetEclassData(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test eclasses
+	for _, name := range []string{"foo", "bar", "baz"} {
+		path := filepath.Join(eclassDir, name+".eclass")
+		if err := os.WriteFile(path, []byte("# "+name), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get subset
+	data, err := c.GetEclassData([]string{"foo", "bar"})
+	if err != nil {
+		t.Fatalf("GetEclassData failed: %v", err)
+	}
+
+	if len(data) != 2 {
+		t.Errorf("expected 2 eclasses, got %d", len(data))
+	}
+
+	if _, ok := data["foo"]; !ok {
+		t.Error("expected 'foo' in data")
+	}
+	if _, ok := data["bar"]; !ok {
+		t.Error("expected 'bar' in data")
+	}
+
+	// Request missing eclass
+	_, err = c.GetEclassData([]string{"foo", "nonexistent"})
+	if err == nil {
+		t.Error("expected error for nonexistent eclass")
+	}
+}
+
+func TestEclassID(t *testing.T) {
+	e := &Eclass{
+		Name:     "test",
+		RepoName: "gentoo",
+	}
+
+	expected := "test@gentoo"
+	if e.ID() != expected {
+		t.Errorf("expected ID %s, got %s", expected, e.ID())
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsAt(s, substr))
+}
+
+func containsAt(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/eclass/doc.go
+++ b/internal/eclass/doc.go
@@ -1,0 +1,73 @@
+// Package eclass provides dynamic eclass loading and execution for GRPM.
+//
+// This package replaces hardcoded Go eclass implementations with dynamic
+// loading from repository eclass/ directories. This approach ensures:
+//
+//   - Gentoo eclass updates propagate to GRPM automatically
+//   - Custom overlay eclasses work correctly
+//   - Different repositories can have different eclass versions
+//
+// # Architecture
+//
+// The package consists of three main components:
+//
+//   - Cache: Discovers and caches eclass files from repository directories
+//   - Executor: Executes eclasses via mvdan.cc/sh bash interpreter
+//   - HybridLoader: Provides fallback to Go implementations when needed
+//
+// # Usage
+//
+// Basic usage for dynamic eclass loading:
+//
+//	// Create cache from repository paths
+//	cache, err := eclass.NewCacheWithLocations([]string{
+//	    "/var/db/repos/gentoo/eclass",
+//	    "/var/db/repos/guru/eclass",
+//	})
+//
+//	// Create executor
+//	exec := eclass.NewExecutor(cache,
+//	    eclass.WithOutput(os.Stdout, os.Stderr),
+//	)
+//
+//	// Inherit eclasses
+//	ctx := context.Background()
+//	if err := exec.Inherit(ctx, []string{"cmake", "multilib-minimal"}); err != nil {
+//	    log.Fatalf("inherit failed: %v", err)
+//	}
+//
+//	// Get accumulated metadata
+//	metadata := exec.GetAccumulatedMetadata()
+//	fmt.Println("DEPEND:", metadata["DEPEND"])
+//
+// # Hybrid Loading
+//
+// For production use, the HybridLoader provides fallback to Go implementations:
+//
+//	loader := eclass.NewHybridLoader(cache, execHandler,
+//	    eclass.WithGoFallback(cmakeImpl),
+//	    eclass.WithVerbose(true),
+//	)
+//
+//	if err := loader.Inherit(ctx, []string{"cmake"}); err != nil {
+//	    // Falls back to Go implementation if dynamic loading fails
+//	}
+//
+// # Integration with ebuild Package
+//
+// Use the bridge in internal/ebuild to integrate with existing infrastructure:
+//
+//	cache, _ := ebuild.CreateDefaultEclassCache()
+//	loader, err := ebuild.SetupDynamicEclassLoading(interp, cache)
+//
+// # Portage Compatibility
+//
+// This implementation follows Portage's eclass loading semantics:
+//
+//   - Eclass directories are searched in priority order (masters -> repo -> overlays)
+//   - Metadata variables (DEPEND, IUSE, etc.) are accumulated across inherits
+//   - EXPORT_FUNCTIONS declarations are supported
+//   - Already-inherited eclasses are skipped
+//
+// Reference: Portage lib/portage/eclass_cache.py and bin/ebuild.sh
+package eclass

--- a/internal/eclass/executor.go
+++ b/internal/eclass/executor.go
@@ -1,0 +1,500 @@
+// Package eclass provides dynamic eclass loading and execution.
+//
+// This file implements the EclassExecutor which loads and executes
+// eclasses dynamically using the mvdan.cc/sh bash interpreter.
+package eclass
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"mvdan.cc/sh/v3/expand"
+	"mvdan.cc/sh/v3/interp"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// MetadataVars lists the metadata variables that are accumulated during inherit.
+// These are backed up before sourcing an eclass and restored after.
+var MetadataVars = []string{
+	"IUSE",
+	"REQUIRED_USE",
+	"DEPEND",
+	"RDEPEND",
+	"PDEPEND",
+	"BDEPEND",
+	"IDEPEND",
+	"PROPERTIES",
+	"RESTRICT",
+}
+
+// Executor executes eclasses dynamically using the mvdan.cc/sh interpreter.
+//
+// It implements the Portage inherit() semantics:
+//   - Sources eclass files in the shell environment
+//   - Accumulates metadata (DEPEND, IUSE, etc.) incrementally
+//   - Handles EXPORT_FUNCTIONS declarations
+//   - Supports nested inheritance (eclass inheriting eclass)
+//
+// Thread-safe: Methods can be called concurrently.
+type Executor struct {
+	mu sync.RWMutex
+
+	// cache is the eclass cache for file lookup.
+	cache *Cache
+
+	// env stores the current shell environment.
+	env map[string]string
+
+	// parser is reused for parsing eclass files.
+	parser *syntax.Parser
+
+	// stdout and stderr for output.
+	stdout io.Writer
+	stderr io.Writer
+
+	// inherited tracks which eclasses have been loaded (INHERITED variable).
+	inherited []string
+
+	// exportedFunctions maps phase name to eclass that exports it.
+	exportedFunctions map[string]string
+
+	// currentEclass is the currently executing eclass (ECLASS variable).
+	currentEclass string
+
+	// eclassDepth tracks nested inherit depth.
+	eclassDepth int
+
+	// accumulatedMetadata stores accumulated values from eclasses.
+	// Key format: "E_" + varname (e.g., E_DEPEND, E_IUSE).
+	accumulatedMetadata map[string]string
+
+	// execHandler is the optional exec handler for Go helper functions.
+	execHandler interp.ExecHandlerFunc
+
+	// openHandler is the optional open handler for file operations.
+	openHandler interp.OpenHandlerFunc
+}
+
+// ExecutorOption configures an Executor.
+type ExecutorOption func(*Executor)
+
+// WithExecHandler sets a custom exec handler for intercepting commands.
+//
+// This allows integration with Go helper implementations (tc-getCC, use, etc.).
+func WithExecHandler(handler interp.ExecHandlerFunc) ExecutorOption {
+	return func(e *Executor) {
+		e.execHandler = handler
+	}
+}
+
+// WithOpenHandler sets a custom open handler for file operations.
+func WithOpenHandler(handler interp.OpenHandlerFunc) ExecutorOption {
+	return func(e *Executor) {
+		e.openHandler = handler
+	}
+}
+
+// WithOutput sets stdout and stderr for the executor.
+func WithOutput(stdout, stderr io.Writer) ExecutorOption {
+	return func(e *Executor) {
+		e.stdout = stdout
+		e.stderr = stderr
+	}
+}
+
+// WithEnvironment sets initial environment variables.
+func WithEnvironment(env map[string]string) ExecutorOption {
+	return func(e *Executor) {
+		for k, v := range env {
+			e.env[k] = v
+		}
+	}
+}
+
+// NewExecutor creates a new eclass executor.
+//
+// Parameters:
+//   - cache: The eclass cache for file lookup
+//   - opts: Optional configuration options
+func NewExecutor(cache *Cache, opts ...ExecutorOption) *Executor {
+	e := &Executor{
+		cache:               cache,
+		env:                 make(map[string]string),
+		parser:              syntax.NewParser(syntax.Variant(syntax.LangBash)),
+		stdout:              os.Stdout,
+		stderr:              os.Stderr,
+		inherited:           make([]string, 0),
+		exportedFunctions:   make(map[string]string),
+		accumulatedMetadata: make(map[string]string),
+	}
+
+	for _, opt := range opts {
+		opt(e)
+	}
+
+	return e
+}
+
+// Inherit loads one or more eclasses.
+//
+// This is the core function implementing inherit() from Portage ebuild.sh.
+// It sources each eclass file, handles metadata accumulation, and tracks
+// the INHERITED variable.
+//
+// Per Portage behavior:
+//   - Already-inherited eclasses are skipped (no double-loading)
+//   - Metadata variables are backed up, eclass is sourced, then metadata is accumulated
+//   - ECLASS and ECLASS_DEPTH are set during execution
+func (e *Executor) Inherit(ctx context.Context, eclasses []string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.eclassDepth++
+	defer func() { e.eclassDepth-- }()
+
+	if e.eclassDepth > 1 {
+		e.writeStderr(fmt.Sprintf(">>> Multiple Inheritance (Level: %d)\n", e.eclassDepth))
+	}
+
+	for _, name := range eclasses {
+		if err := e.inheritSingleLocked(ctx, name); err != nil {
+			return fmt.Errorf("inheriting %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// inheritSingleLocked loads a single eclass.
+// Must be called with lock held.
+func (e *Executor) inheritSingleLocked(ctx context.Context, name string) error {
+	// Check if already inherited
+	for _, existing := range e.inherited {
+		if existing == name {
+			e.writeStdout(fmt.Sprintf(">>> Eclass %s already inherited (skipping)\n", name))
+			return nil
+		}
+	}
+
+	e.writeStdout(fmt.Sprintf(">>> Inheriting eclass: %s\n", name))
+
+	// Look up eclass in cache
+	eclass, err := e.cache.Get(name)
+	if err != nil {
+		return err
+	}
+
+	// Set current eclass
+	prevEclass := e.currentEclass
+	e.currentEclass = name
+	e.env["ECLASS"] = name
+	defer func() {
+		e.currentEclass = prevEclass
+		if prevEclass != "" {
+			e.env["ECLASS"] = prevEclass
+		} else {
+			delete(e.env, "ECLASS")
+		}
+	}()
+
+	// Backup metadata variables
+	backup := e.backupMetadata()
+
+	// Unset metadata variables before sourcing
+	for _, varName := range MetadataVars {
+		delete(e.env, varName)
+	}
+
+	// Read and parse eclass content
+	content, err := os.ReadFile(eclass.Path)
+	if err != nil {
+		return fmt.Errorf("reading eclass %s: %w", name, err)
+	}
+
+	// Execute eclass content
+	if err := e.executeScript(ctx, string(content), eclass.Path); err != nil {
+		return fmt.Errorf("executing eclass %s: %w", name, err)
+	}
+
+	// Accumulate metadata
+	e.accumulateMetadata(backup)
+
+	// Mark as inherited
+	e.inherited = append(e.inherited, name)
+	e.env["INHERITED"] = strings.Join(e.inherited, " ")
+
+	return nil
+}
+
+// backupMetadata saves current values of metadata variables.
+func (e *Executor) backupMetadata() map[string]string {
+	backup := make(map[string]string)
+	for _, varName := range MetadataVars {
+		if val, ok := e.env[varName]; ok {
+			backup[varName] = val
+		}
+	}
+	return backup
+}
+
+// accumulateMetadata merges eclass-set metadata into accumulated values.
+//
+// Per Portage behavior:
+//   - Eclass-set values are appended to E_* accumulator variables
+//   - Original values (from backup) are restored to the original variables
+func (e *Executor) accumulateMetadata(backup map[string]string) {
+	for _, varName := range MetadataVars {
+		// If eclass set this variable, append to accumulator
+		if val, ok := e.env[varName]; ok && val != "" {
+			accKey := "E_" + varName
+			if existing := e.accumulatedMetadata[accKey]; existing != "" {
+				e.accumulatedMetadata[accKey] = existing + " " + val
+			} else {
+				e.accumulatedMetadata[accKey] = val
+			}
+		}
+
+		// Restore backed-up value (or unset if wasn't set)
+		if backedUp, ok := backup[varName]; ok {
+			e.env[varName] = backedUp
+		} else {
+			delete(e.env, varName)
+		}
+	}
+}
+
+// executeScript runs a bash script in the executor's environment.
+func (e *Executor) executeScript(ctx context.Context, script, filename string) error {
+	prog, err := e.parser.Parse(strings.NewReader(script), filename)
+	if err != nil {
+		return fmt.Errorf("parsing script: %w", err)
+	}
+
+	// Create runner with current environment
+	runner, err := e.createRunner(ctx)
+	if err != nil {
+		return fmt.Errorf("creating runner: %w", err)
+	}
+
+	// Execute
+	if err := runner.Run(ctx, prog); err != nil {
+		return err
+	}
+
+	// Update environment from runner
+	e.updateEnvFromRunner(runner)
+
+	return nil
+}
+
+// createRunner creates a new shell interpreter runner.
+func (e *Executor) createRunner(ctx context.Context) (*interp.Runner, error) {
+	// Convert env map to slice
+	envPairs := make([]string, 0, len(e.env))
+	for k, v := range e.env {
+		envPairs = append(envPairs, k+"="+v)
+	}
+
+	// Build options
+	opts := []interp.RunnerOption{
+		interp.StdIO(nil, e.stdout, e.stderr),
+		interp.Env(expand.ListEnviron(envPairs...)),
+	}
+
+	// Add exec handler if provided
+	if e.execHandler != nil {
+		opts = append(opts, interp.ExecHandlers(func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
+			return e.execHandler
+		}))
+	}
+
+	// Add open handler if provided
+	if e.openHandler != nil {
+		opts = append(opts, interp.OpenHandler(e.openHandler))
+	}
+
+	return interp.New(opts...)
+}
+
+// updateEnvFromRunner syncs environment changes from the runner back to executor.
+func (e *Executor) updateEnvFromRunner(runner *interp.Runner) {
+	// Iterate over all variables in the runner's Vars map
+	for name, vr := range runner.Vars {
+		// Get the string value
+		if str := vr.String(); str != "" {
+			e.env[name] = str
+		}
+	}
+}
+
+// ExportFunctions registers phase functions from the current eclass.
+//
+// Usage: EXPORT_FUNCTIONS src_compile src_install
+//
+// After this call, when src_compile is invoked, it will call ${ECLASS}_src_compile.
+func (e *Executor) ExportFunctions(phases []string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.currentEclass == "" {
+		return fmt.Errorf("EXPORT_FUNCTIONS called without a defined ECLASS")
+	}
+
+	for _, phase := range phases {
+		e.exportedFunctions[phase] = e.currentEclass
+	}
+
+	return nil
+}
+
+// GetExportedFunction returns the eclass that exports a phase function.
+//
+// Returns the eclass name and true if found, empty string and false otherwise.
+func (e *Executor) GetExportedFunction(phase string) (string, bool) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	eclass, ok := e.exportedFunctions[phase]
+	return eclass, ok
+}
+
+// GetInherited returns the list of inherited eclasses.
+func (e *Executor) GetInherited() []string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	result := make([]string, len(e.inherited))
+	copy(result, e.inherited)
+	return result
+}
+
+// GetInheritedString returns the INHERITED variable value.
+func (e *Executor) GetInheritedString() string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return strings.Join(e.inherited, " ")
+}
+
+// GetAccumulatedMetadata returns accumulated metadata variables.
+//
+// These are the E_* variables containing merged values from all eclasses.
+func (e *Executor) GetAccumulatedMetadata() map[string]string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	result := make(map[string]string, len(e.accumulatedMetadata))
+	for k, v := range e.accumulatedMetadata {
+		result[k] = v
+	}
+	return result
+}
+
+// GetEnv returns the current environment.
+func (e *Executor) GetEnv() map[string]string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	result := make(map[string]string, len(e.env))
+	for k, v := range e.env {
+		result[k] = v
+	}
+	return result
+}
+
+// GetVar returns an environment variable value.
+func (e *Executor) GetVar(name string) string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.env[name]
+}
+
+// SetVar sets an environment variable.
+func (e *Executor) SetVar(name, value string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.env[name] = value
+}
+
+// FinalizeMetadata merges accumulated metadata into the environment.
+//
+// Call this after all inherit() calls are complete to get the final
+// merged values. This combines ebuild-defined values with eclass-accumulated values.
+//
+// For each metadata variable:
+//   - If ebuild defined it: ebuild_value + " " + accumulated_value
+//   - If only eclass defined it: accumulated_value
+func (e *Executor) FinalizeMetadata() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	for _, varName := range MetadataVars {
+		accKey := "E_" + varName
+		accValue, hasAcc := e.accumulatedMetadata[accKey]
+		ebuildValue, hasEbuild := e.env[varName]
+
+		if hasAcc {
+			if hasEbuild && ebuildValue != "" {
+				// Ebuild value takes precedence, append accumulated
+				e.env[varName] = ebuildValue + " " + accValue
+			} else {
+				// Only accumulated value
+				e.env[varName] = accValue
+			}
+		}
+	}
+}
+
+// Run executes a bash script in the executor's environment.
+//
+// This is useful for running ebuild scripts after eclasses are loaded.
+func (e *Executor) Run(ctx context.Context, script string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.executeScript(ctx, script, "script")
+}
+
+// RunFile executes a bash script file.
+func (e *Executor) RunFile(ctx context.Context, path string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading script %s: %w", path, err)
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.executeScript(ctx, string(content), path)
+}
+
+// Reset clears the executor state for reuse.
+func (e *Executor) Reset() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.inherited = make([]string, 0)
+	e.exportedFunctions = make(map[string]string)
+	e.accumulatedMetadata = make(map[string]string)
+	e.currentEclass = ""
+	e.eclassDepth = 0
+
+	// Keep base environment but clear eclass-related vars
+	delete(e.env, "ECLASS")
+	delete(e.env, "INHERITED")
+	for _, varName := range MetadataVars {
+		delete(e.env, varName)
+		delete(e.env, "E_"+varName)
+	}
+}
+
+// writeStdout writes to stdout.
+func (e *Executor) writeStdout(s string) {
+	if e.stdout != nil {
+		_, _ = io.WriteString(e.stdout, s)
+	}
+}
+
+// writeStderr writes to stderr.
+func (e *Executor) writeStderr(s string) {
+	if e.stderr != nil {
+		_, _ = io.WriteString(e.stderr, s)
+	}
+}

--- a/internal/eclass/executor_test.go
+++ b/internal/eclass/executor_test.go
@@ -1,0 +1,472 @@
+package eclass
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewExecutor(t *testing.T) {
+	cache := NewCache()
+	exec := NewExecutor(cache)
+
+	if exec == nil {
+		t.Fatal("NewExecutor returned nil")
+	}
+
+	if exec.cache != cache {
+		t.Error("executor cache not set correctly")
+	}
+}
+
+func TestExecutorInherit(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a simple eclass
+	eclassContent := `
+# test.eclass
+IUSE="test-flag"
+DEPEND="dev-libs/foo"
+
+test_func() {
+    echo "test function"
+}
+`
+	if err := os.WriteFile(filepath.Join(eclassDir, "test.eclass"), []byte(eclassContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exec := NewExecutor(cache, WithOutput(&stdout, &stderr))
+
+	ctx := context.Background()
+	if err := exec.Inherit(ctx, []string{"test"}); err != nil {
+		t.Fatalf("Inherit failed: %v", err)
+	}
+
+	// Check inherited list
+	inherited := exec.GetInherited()
+	if len(inherited) != 1 || inherited[0] != "test" {
+		t.Errorf("expected inherited=[test], got %v", inherited)
+	}
+
+	// Check INHERITED env var
+	inheritedStr := exec.GetInheritedString()
+	if inheritedStr != "test" {
+		t.Errorf("expected INHERITED=test, got %s", inheritedStr)
+	}
+}
+
+func TestExecutorMetadataAccumulation(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create first eclass
+	eclass1 := `
+# eclass1.eclass
+IUSE="flag1"
+DEPEND="dev-libs/lib1"
+`
+	if err := os.WriteFile(filepath.Join(eclassDir, "eclass1.eclass"), []byte(eclass1), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create second eclass
+	eclass2 := `
+# eclass2.eclass
+IUSE="flag2"
+DEPEND="dev-libs/lib2"
+`
+	if err := os.WriteFile(filepath.Join(eclassDir, "eclass2.eclass"), []byte(eclass2), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exec := NewExecutor(cache, WithOutput(&stdout, &stderr))
+
+	ctx := context.Background()
+
+	// Inherit both eclasses
+	if err := exec.Inherit(ctx, []string{"eclass1", "eclass2"}); err != nil {
+		t.Fatalf("Inherit failed: %v", err)
+	}
+
+	// Check accumulated metadata
+	accum := exec.GetAccumulatedMetadata()
+
+	// IUSE should be accumulated
+	if iuse, ok := accum["E_IUSE"]; !ok {
+		t.Error("E_IUSE not found in accumulated metadata")
+	} else if !strings.Contains(iuse, "flag1") || !strings.Contains(iuse, "flag2") {
+		t.Errorf("expected IUSE to contain flag1 and flag2, got: %s", iuse)
+	}
+
+	// DEPEND should be accumulated
+	if depend, ok := accum["E_DEPEND"]; !ok {
+		t.Error("E_DEPEND not found in accumulated metadata")
+	} else if !strings.Contains(depend, "lib1") || !strings.Contains(depend, "lib2") {
+		t.Errorf("expected DEPEND to contain lib1 and lib2, got: %s", depend)
+	}
+}
+
+func TestExecutorDoubleInherit(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create eclass
+	eclassContent := `
+# test.eclass
+IUSE="test"
+`
+	if err := os.WriteFile(filepath.Join(eclassDir, "test.eclass"), []byte(eclassContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exec := NewExecutor(cache, WithOutput(&stdout, &stderr))
+
+	ctx := context.Background()
+
+	// Inherit same eclass twice
+	if err := exec.Inherit(ctx, []string{"test"}); err != nil {
+		t.Fatalf("First inherit failed: %v", err)
+	}
+	if err := exec.Inherit(ctx, []string{"test"}); err != nil {
+		t.Fatalf("Second inherit failed: %v", err)
+	}
+
+	// Should only be in list once
+	inherited := exec.GetInherited()
+	if len(inherited) != 1 {
+		t.Errorf("expected 1 inherited eclass, got %d", len(inherited))
+	}
+
+	// Stdout should mention skipping
+	if !strings.Contains(stdout.String(), "skipping") {
+		t.Error("expected 'skipping' message for double inherit")
+	}
+}
+
+func TestExecutorNestedInherit(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create base eclass
+	baseEclass := `
+# base.eclass
+IUSE="base-flag"
+base_func() {
+    echo "base"
+}
+`
+	if err := os.WriteFile(filepath.Join(eclassDir, "base.eclass"), []byte(baseEclass), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create child eclass that inherits base
+	// Note: We simulate inherit by just setting variables - actual inherit
+	// would require full interpreter integration
+	childEclass := `
+# child.eclass
+IUSE="child-flag"
+child_func() {
+    echo "child"
+}
+`
+	if err := os.WriteFile(filepath.Join(eclassDir, "child.eclass"), []byte(childEclass), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exec := NewExecutor(cache, WithOutput(&stdout, &stderr))
+
+	ctx := context.Background()
+
+	// Inherit base first, then child
+	if err := exec.Inherit(ctx, []string{"base", "child"}); err != nil {
+		t.Fatalf("Inherit failed: %v", err)
+	}
+
+	// Both should be inherited
+	inherited := exec.GetInherited()
+	if len(inherited) != 2 {
+		t.Errorf("expected 2 inherited eclasses, got %d", len(inherited))
+	}
+}
+
+func TestExecutorExportFunctions(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exec := NewExecutor(cache)
+
+	// Export without ECLASS should fail
+	err = exec.ExportFunctions([]string{"src_compile"})
+	if err == nil {
+		t.Error("expected error for EXPORT_FUNCTIONS without ECLASS")
+	}
+
+	// Set ECLASS and try again
+	exec.mu.Lock()
+	exec.currentEclass = "cmake"
+	exec.mu.Unlock()
+
+	err = exec.ExportFunctions([]string{"src_compile", "src_install"})
+	if err != nil {
+		t.Fatalf("ExportFunctions failed: %v", err)
+	}
+
+	// Check exported functions
+	eclass, ok := exec.GetExportedFunction("src_compile")
+	if !ok || eclass != "cmake" {
+		t.Errorf("expected src_compile exported by cmake, got %s, %v", eclass, ok)
+	}
+
+	eclass, ok = exec.GetExportedFunction("src_install")
+	if !ok || eclass != "cmake" {
+		t.Errorf("expected src_install exported by cmake, got %s, %v", eclass, ok)
+	}
+
+	// Non-exported function should return false
+	_, ok = exec.GetExportedFunction("src_test")
+	if ok {
+		t.Error("expected src_test to not be exported")
+	}
+}
+
+func TestExecutorRun(t *testing.T) {
+	cache := NewCache()
+
+	var stdout, stderr bytes.Buffer
+	exec := NewExecutor(cache, WithOutput(&stdout, &stderr))
+
+	ctx := context.Background()
+
+	// Run a simple script
+	script := `
+FOO="bar"
+echo "Hello from script"
+`
+	if err := exec.Run(ctx, script); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "Hello from script") {
+		t.Errorf("expected output 'Hello from script', got: %s", stdout.String())
+	}
+
+	// Variable should be set
+	foo := exec.GetVar("FOO")
+	if foo != "bar" {
+		t.Errorf("expected FOO=bar, got FOO=%s", foo)
+	}
+}
+
+func TestExecutorSetGetVar(t *testing.T) {
+	cache := NewCache()
+	exec := NewExecutor(cache)
+
+	exec.SetVar("TEST", "value")
+	val := exec.GetVar("TEST")
+
+	if val != "value" {
+		t.Errorf("expected TEST=value, got TEST=%s", val)
+	}
+}
+
+func TestExecutorReset(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	eclassContent := `
+# test.eclass
+IUSE="test"
+`
+	if err := os.WriteFile(filepath.Join(eclassDir, "test.eclass"), []byte(eclassContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exec := NewExecutor(cache, WithOutput(&stdout, &stderr))
+
+	ctx := context.Background()
+
+	// Inherit and accumulate state
+	if err := exec.Inherit(ctx, []string{"test"}); err != nil {
+		t.Fatalf("Inherit failed: %v", err)
+	}
+
+	// Set some variables
+	exec.SetVar("CUSTOM", "value")
+
+	// Reset
+	exec.Reset()
+
+	// Check state is cleared
+	inherited := exec.GetInherited()
+	if len(inherited) != 0 {
+		t.Errorf("expected empty inherited after reset, got %v", inherited)
+	}
+
+	accum := exec.GetAccumulatedMetadata()
+	if len(accum) != 0 {
+		t.Errorf("expected empty accumulated metadata after reset, got %v", accum)
+	}
+
+	// CUSTOM should still be there (non-metadata vars preserved)
+	if exec.GetVar("CUSTOM") != "value" {
+		t.Error("expected CUSTOM to be preserved after reset")
+	}
+}
+
+func TestExecutorFinalizeMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create eclass with DEPEND
+	eclassContent := `
+# test.eclass
+DEPEND="eclass-dep"
+`
+	if err := os.WriteFile(filepath.Join(eclassDir, "test.eclass"), []byte(eclassContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exec := NewExecutor(cache, WithOutput(&stdout, &stderr))
+
+	ctx := context.Background()
+
+	// Inherit eclass
+	if err := exec.Inherit(ctx, []string{"test"}); err != nil {
+		t.Fatalf("Inherit failed: %v", err)
+	}
+
+	// Simulate ebuild setting its own DEPEND
+	exec.SetVar("DEPEND", "ebuild-dep")
+
+	// Finalize
+	exec.FinalizeMetadata()
+
+	// DEPEND should be ebuild-dep + eclass-dep
+	depend := exec.GetVar("DEPEND")
+	if !strings.Contains(depend, "ebuild-dep") || !strings.Contains(depend, "eclass-dep") {
+		t.Errorf("expected DEPEND to contain both ebuild-dep and eclass-dep, got: %s", depend)
+	}
+}
+
+func TestExecutorWithEnvironment(t *testing.T) {
+	cache := NewCache()
+
+	initialEnv := map[string]string{
+		"P":        "test-1.0",
+		"PN":       "test",
+		"PV":       "1.0",
+		"CATEGORY": "app-misc",
+	}
+
+	exec := NewExecutor(cache, WithEnvironment(initialEnv))
+
+	env := exec.GetEnv()
+	for k, v := range initialEnv {
+		if env[k] != v {
+			t.Errorf("expected %s=%s, got %s=%s", k, v, k, env[k])
+		}
+	}
+}
+
+func TestExecutorEclassNotFound(t *testing.T) {
+	cache := NewCache()
+
+	var stdout, stderr bytes.Buffer
+	exec := NewExecutor(cache, WithOutput(&stdout, &stderr))
+
+	ctx := context.Background()
+
+	err := exec.Inherit(ctx, []string{"nonexistent"})
+	if err == nil {
+		t.Error("expected error for nonexistent eclass")
+	}
+
+	if !IsEclassNotFound(err) && !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestExecutorGetEnv(t *testing.T) {
+	cache := NewCache()
+	exec := NewExecutor(cache)
+
+	exec.SetVar("A", "1")
+	exec.SetVar("B", "2")
+
+	env := exec.GetEnv()
+
+	// Verify it's a copy
+	env["A"] = "modified"
+
+	// Original should be unchanged
+	if exec.GetVar("A") != "1" {
+		t.Error("GetEnv should return a copy, not the original")
+	}
+}

--- a/internal/eclass/integration.go
+++ b/internal/eclass/integration.go
@@ -1,0 +1,279 @@
+// Package eclass provides dynamic eclass loading and execution.
+//
+// This file provides integration utilities for connecting the eclass
+// package with the existing ebuild execution infrastructure.
+package eclass
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"mvdan.cc/sh/v3/interp"
+)
+
+// HybridLoader provides hybrid eclass loading with dynamic execution
+// and fallback to Go implementations.
+//
+// It tries dynamic loading first, then falls back to registered Go
+// implementations for eclasses that cannot be dynamically executed.
+type HybridLoader struct {
+	// cache is the eclass cache for file lookup.
+	cache *Cache
+
+	// executor is the dynamic executor.
+	executor *Executor
+
+	// goFallbacks maps eclass name to Go implementation.
+	goFallbacks map[string]GoEclassImpl
+
+	// stdout and stderr for output.
+	stdout io.Writer
+	stderr io.Writer
+
+	// verbose enables verbose logging.
+	verbose bool
+}
+
+// GoEclassImpl is a Go implementation of an eclass.
+//
+// This allows keeping existing Go implementations as fallbacks
+// when dynamic execution fails or for performance-critical eclasses.
+type GoEclassImpl interface {
+	// Name returns the eclass name (e.g., "cmake", "meson").
+	Name() string
+
+	// Execute runs the eclass setup with the given environment.
+	// It should modify env to add IUSE, DEPEND, etc.
+	Execute(ctx context.Context, env map[string]string) error
+
+	// HasPhaseFunction checks if the eclass provides a phase function.
+	HasPhaseFunction(phase string) bool
+
+	// ExecutePhase runs a phase function.
+	ExecutePhase(ctx context.Context, phase string, env map[string]string) error
+}
+
+// HybridLoaderOption configures a HybridLoader.
+type HybridLoaderOption func(*HybridLoader)
+
+// WithGoFallback registers a Go eclass implementation as fallback.
+func WithGoFallback(impl GoEclassImpl) HybridLoaderOption {
+	return func(h *HybridLoader) {
+		h.goFallbacks[impl.Name()] = impl
+	}
+}
+
+// WithVerbose enables verbose logging.
+func WithVerbose(verbose bool) HybridLoaderOption {
+	return func(h *HybridLoader) {
+		h.verbose = verbose
+	}
+}
+
+// WithHybridOutput sets stdout and stderr.
+func WithHybridOutput(stdout, stderr io.Writer) HybridLoaderOption {
+	return func(h *HybridLoader) {
+		h.stdout = stdout
+		h.stderr = stderr
+	}
+}
+
+// NewHybridLoader creates a new hybrid loader.
+func NewHybridLoader(cache *Cache, execHandler interp.ExecHandlerFunc, opts ...HybridLoaderOption) *HybridLoader {
+	h := &HybridLoader{
+		cache:       cache,
+		goFallbacks: make(map[string]GoEclassImpl),
+		stdout:      os.Stdout,
+		stderr:      os.Stderr,
+	}
+
+	for _, opt := range opts {
+		opt(h)
+	}
+
+	// Create executor with the exec handler
+	execOpts := []ExecutorOption{
+		WithOutput(h.stdout, h.stderr),
+	}
+	if execHandler != nil {
+		execOpts = append(execOpts, WithExecHandler(execHandler))
+	}
+	h.executor = NewExecutor(cache, execOpts...)
+
+	return h
+}
+
+// Inherit loads one or more eclasses using hybrid approach.
+//
+// For each eclass:
+//  1. Try dynamic loading from cache
+//  2. If dynamic loading fails, try Go fallback
+//  3. If both fail, return error
+func (h *HybridLoader) Inherit(ctx context.Context, eclasses []string) error {
+	for _, name := range eclasses {
+		if err := h.inheritSingle(ctx, name); err != nil {
+			return fmt.Errorf("inheriting %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func (h *HybridLoader) inheritSingle(ctx context.Context, name string) error {
+	// Check if already inherited
+	if h.executor.GetInheritedString() != "" {
+		for _, existing := range strings.Fields(h.executor.GetInheritedString()) {
+			if existing == name {
+				h.writeStdout(fmt.Sprintf(">>> Eclass %s already inherited (skipping)\n", name))
+				return nil
+			}
+		}
+	}
+
+	// Try dynamic loading first
+	if h.cache.Has(name) {
+		err := h.executor.Inherit(ctx, []string{name})
+		if err == nil {
+			if h.verbose {
+				h.writeStdout(fmt.Sprintf(">>> Eclass %s loaded dynamically\n", name))
+			}
+			return nil
+		}
+
+		// Dynamic loading failed - try fallback
+		if h.verbose {
+			h.writeStderr(fmt.Sprintf(">>> Dynamic loading failed for %s: %v\n", name, err))
+		}
+	}
+
+	// Try Go fallback
+	if impl, ok := h.goFallbacks[name]; ok {
+		if h.verbose {
+			h.writeStdout(fmt.Sprintf(">>> Using Go fallback for eclass %s\n", name))
+		}
+		env := h.executor.GetEnv()
+		if err := impl.Execute(ctx, env); err != nil {
+			return fmt.Errorf("go fallback for %s: %w", name, err)
+		}
+		// Update executor env from Go impl
+		for k, v := range env {
+			h.executor.SetVar(k, v)
+		}
+		return nil
+	}
+
+	// Both failed
+	return &EclassNotFoundError{Name: name, Locations: h.cache.Locations()}
+}
+
+// GetExecutor returns the underlying executor.
+func (h *HybridLoader) GetExecutor() *Executor {
+	return h.executor
+}
+
+// GetCache returns the eclass cache.
+func (h *HybridLoader) GetCache() *Cache {
+	return h.cache
+}
+
+// HasGoFallback checks if a Go fallback exists for an eclass.
+func (h *HybridLoader) HasGoFallback(name string) bool {
+	_, ok := h.goFallbacks[name]
+	return ok
+}
+
+func (h *HybridLoader) writeStdout(s string) {
+	if h.stdout != nil {
+		_, _ = io.WriteString(h.stdout, s)
+	}
+}
+
+func (h *HybridLoader) writeStderr(s string) {
+	if h.stderr != nil {
+		_, _ = io.WriteString(h.stderr, s)
+	}
+}
+
+// BuildCacheFromRepos builds an eclass cache from repository paths.
+//
+// Parameters:
+//   - repos: List of repository root paths (e.g., /var/db/repos/gentoo)
+//   - masters: Optional map of repo name to its master repos
+//
+// The first repo is treated as the master (lowest priority for deduplication).
+func BuildCacheFromRepos(repos []string, masters map[string][]string) (*Cache, error) {
+	cache := NewCache()
+
+	for i, repoPath := range repos {
+		eclassDir := filepath.Join(repoPath, "eclass")
+		repoName := filepath.Base(repoPath)
+
+		// Check if directory exists
+		if _, err := os.Stat(eclassDir); os.IsNotExist(err) {
+			continue
+		}
+
+		// First repo is master
+		if i == 0 {
+			cache.masterEclassDir = eclassDir
+		}
+
+		cache.repoNames[eclassDir] = repoName
+
+		// Add masters for this repo if specified
+		if m, ok := masters[repoName]; ok {
+			for _, masterName := range m {
+				for _, r := range repos {
+					if filepath.Base(r) == masterName {
+						masterEclass := filepath.Join(r, "eclass")
+						if !cache.hasLocation(masterEclass) {
+							cache.locations = append(cache.locations, masterEclass)
+							if err := cache.scanDirectoryLocked(masterEclass); err != nil {
+								continue
+							}
+						}
+						break
+					}
+				}
+			}
+		}
+
+		// Add this repo
+		if !cache.hasLocation(eclassDir) {
+			cache.locations = append(cache.locations, eclassDir)
+			if err := cache.scanDirectoryLocked(eclassDir); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return cache, nil
+}
+
+// DefaultLocations returns the default eclass search locations.
+func DefaultLocations() []string {
+	return []string{
+		"/var/db/repos/gentoo/eclass",
+		"/usr/portage/eclass",
+	}
+}
+
+// FindRepositoryEclass finds an eclass in repository eclass directories.
+//
+// This is a utility for locating eclass files when you have repository
+// paths but not a full cache.
+func FindRepositoryEclass(name string, repoPaths []string) (string, error) {
+	eclassFile := name + ".eclass"
+
+	for _, repoPath := range repoPaths {
+		path := filepath.Join(repoPath, "eclass", eclassFile)
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", &EclassNotFoundError{Name: name, Locations: repoPaths}
+}

--- a/internal/eclass/integration_test.go
+++ b/internal/eclass/integration_test.go
@@ -1,0 +1,275 @@
+package eclass
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewHybridLoader(t *testing.T) {
+	cache := NewCache()
+	loader := NewHybridLoader(cache, nil)
+
+	if loader == nil {
+		t.Fatal("NewHybridLoader returned nil")
+	}
+
+	if loader.cache != cache {
+		t.Error("cache not set correctly")
+	}
+
+	if loader.executor == nil {
+		t.Error("executor not created")
+	}
+}
+
+func TestHybridLoaderDynamicInherit(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create test eclass
+	eclassContent := `
+# test.eclass
+IUSE="test-flag"
+DEPEND="dev-libs/test"
+`
+	if err := os.WriteFile(filepath.Join(eclassDir, "test.eclass"), []byte(eclassContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	loader := NewHybridLoader(cache, nil,
+		WithHybridOutput(&stdout, &stderr),
+		WithVerbose(true),
+	)
+
+	ctx := context.Background()
+	if err := loader.Inherit(ctx, []string{"test"}); err != nil {
+		t.Fatalf("Inherit failed: %v", err)
+	}
+
+	// Verify inherited
+	inherited := loader.GetExecutor().GetInherited()
+	if len(inherited) != 1 || inherited[0] != "test" {
+		t.Errorf("expected inherited=['test'], got %v", inherited)
+	}
+}
+
+// MockGoEclass implements GoEclassImpl for testing.
+type MockGoEclass struct {
+	name         string
+	executed     bool
+	phasesCalled map[string]bool
+}
+
+func (m *MockGoEclass) Name() string {
+	return m.name
+}
+
+func (m *MockGoEclass) Execute(ctx context.Context, env map[string]string) error {
+	m.executed = true
+	env["IUSE"] = "mock-flag"
+	env["DEPEND"] = "mock-dep"
+	return nil
+}
+
+func (m *MockGoEclass) HasPhaseFunction(phase string) bool {
+	return phase == "src_compile"
+}
+
+func (m *MockGoEclass) ExecutePhase(ctx context.Context, phase string, env map[string]string) error {
+	if m.phasesCalled == nil {
+		m.phasesCalled = make(map[string]bool)
+	}
+	m.phasesCalled[phase] = true
+	return nil
+}
+
+func TestHybridLoaderGoFallback(t *testing.T) {
+	cache := NewCache() // Empty cache - no dynamic eclasses
+
+	mockEclass := &MockGoEclass{name: "mock"}
+
+	var stdout, stderr bytes.Buffer
+	loader := NewHybridLoader(cache, nil,
+		WithGoFallback(mockEclass),
+		WithHybridOutput(&stdout, &stderr),
+		WithVerbose(true),
+	)
+
+	ctx := context.Background()
+	if err := loader.Inherit(ctx, []string{"mock"}); err != nil {
+		t.Fatalf("Inherit failed: %v", err)
+	}
+
+	if !mockEclass.executed {
+		t.Error("expected Go fallback to be executed")
+	}
+}
+
+func TestHybridLoaderNotFound(t *testing.T) {
+	cache := NewCache()
+
+	var stdout, stderr bytes.Buffer
+	loader := NewHybridLoader(cache, nil,
+		WithHybridOutput(&stdout, &stderr),
+	)
+
+	ctx := context.Background()
+	err := loader.Inherit(ctx, []string{"nonexistent"})
+	if err == nil {
+		t.Error("expected error for nonexistent eclass")
+	}
+}
+
+func TestHybridLoaderHasGoFallback(t *testing.T) {
+	cache := NewCache()
+	mockEclass := &MockGoEclass{name: "test"}
+
+	loader := NewHybridLoader(cache, nil, WithGoFallback(mockEclass))
+
+	if !loader.HasGoFallback("test") {
+		t.Error("expected HasGoFallback('test') to return true")
+	}
+
+	if loader.HasGoFallback("other") {
+		t.Error("expected HasGoFallback('other') to return false")
+	}
+}
+
+func TestBuildCacheFromRepos(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create repo1 (master)
+	repo1 := filepath.Join(tmpDir, "gentoo")
+	repo1Eclass := filepath.Join(repo1, "eclass")
+	if err := os.MkdirAll(repo1Eclass, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo1Eclass, "base.eclass"), []byte("# base"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create repo2 (overlay)
+	repo2 := filepath.Join(tmpDir, "overlay")
+	repo2Eclass := filepath.Join(repo2, "eclass")
+	if err := os.MkdirAll(repo2Eclass, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo2Eclass, "custom.eclass"), []byte("# custom"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := BuildCacheFromRepos([]string{repo1, repo2}, nil)
+	if err != nil {
+		t.Fatalf("BuildCacheFromRepos failed: %v", err)
+	}
+
+	// Should have both eclasses
+	if !cache.Has("base") {
+		t.Error("expected 'base' eclass")
+	}
+	if !cache.Has("custom") {
+		t.Error("expected 'custom' eclass")
+	}
+}
+
+func TestDefaultLocations(t *testing.T) {
+	locs := DefaultLocations()
+
+	if len(locs) < 1 {
+		t.Error("expected at least one default location")
+	}
+
+	// Check that expected paths are present
+	found := false
+	for _, loc := range locs {
+		if loc == "/var/db/repos/gentoo/eclass" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected /var/db/repos/gentoo/eclass in default locations")
+	}
+}
+
+func TestFindRepositoryEclass(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create repo with eclass
+	repo := filepath.Join(tmpDir, "repo")
+	eclassDir := filepath.Join(repo, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	eclassPath := filepath.Join(eclassDir, "test.eclass")
+	if err := os.WriteFile(eclassPath, []byte("# test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Find existing
+	found, err := FindRepositoryEclass("test", []string{repo})
+	if err != nil {
+		t.Fatalf("FindRepositoryEclass failed: %v", err)
+	}
+	if found != eclassPath {
+		t.Errorf("expected %s, got %s", eclassPath, found)
+	}
+
+	// Find nonexistent
+	_, err = FindRepositoryEclass("nonexistent", []string{repo})
+	if err == nil {
+		t.Error("expected error for nonexistent eclass")
+	}
+}
+
+func TestHybridLoaderDoubleInherit(t *testing.T) {
+	tmpDir := t.TempDir()
+	eclassDir := filepath.Join(tmpDir, "eclass")
+	if err := os.MkdirAll(eclassDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(eclassDir, "test.eclass"), []byte("# test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache, err := NewCacheWithLocations([]string{eclassDir})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	loader := NewHybridLoader(cache, nil, WithHybridOutput(&stdout, &stderr))
+
+	ctx := context.Background()
+
+	// First inherit
+	if err := loader.Inherit(ctx, []string{"test"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second inherit (same eclass) should skip
+	stdout.Reset()
+	if err := loader.Inherit(ctx, []string{"test"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should mention skipping
+	output := stdout.String()
+	if output == "" {
+		t.Error("expected output mentioning skip")
+	}
+}

--- a/internal/eclass/metadata.go
+++ b/internal/eclass/metadata.go
@@ -1,0 +1,294 @@
+// Package eclass provides dynamic eclass loading and execution.
+//
+// This file provides metadata handling for eclasses, including
+// EXPORT_FUNCTIONS support and metadata accumulation.
+package eclass
+
+import (
+	"strings"
+	"sync"
+)
+
+// MetadataManager manages metadata accumulation during inherit.
+//
+// It tracks:
+//   - Accumulated metadata (E_DEPEND, E_IUSE, etc.)
+//   - Exported functions from eclasses
+//   - INHERITED list
+//
+// Thread-safe: All methods can be called concurrently.
+type MetadataManager struct {
+	mu sync.RWMutex
+
+	// accumulated stores accumulated metadata from eclasses.
+	// Key format: varname (e.g., DEPEND, IUSE).
+	// These are the E_* variables from Portage.
+	accumulated map[string]string
+
+	// exported maps phase name to the eclass that exports it.
+	exported map[string]string
+
+	// inherited is the list of inherited eclasses.
+	inherited []string
+
+	// currentEclass is the currently executing eclass.
+	currentEclass string
+
+	// depth tracks nesting level of inherit calls.
+	depth int
+}
+
+// NewMetadataManager creates a new metadata manager.
+func NewMetadataManager() *MetadataManager {
+	return &MetadataManager{
+		accumulated: make(map[string]string),
+		exported:    make(map[string]string),
+		inherited:   make([]string, 0),
+	}
+}
+
+// BeginInherit prepares for inheriting an eclass.
+//
+// Returns the backup of current metadata values that should be restored
+// after the eclass is sourced.
+func (m *MetadataManager) BeginInherit(eclassName string, currentEnv map[string]string) map[string]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.depth++
+	m.currentEclass = eclassName
+
+	// Backup current metadata values
+	backup := make(map[string]string)
+	for _, varName := range MetadataVars {
+		if val, ok := currentEnv[varName]; ok {
+			backup[varName] = val
+		}
+	}
+
+	return backup
+}
+
+// EndInherit completes the inherit process.
+//
+// It accumulates metadata set by the eclass and restores the backed-up values.
+// Returns the updated environment with restored values.
+func (m *MetadataManager) EndInherit(eclassName string, newEnv, backup map[string]string) map[string]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.depth--
+
+	// Accumulate metadata set by eclass
+	for _, varName := range MetadataVars {
+		if val, ok := newEnv[varName]; ok && val != "" {
+			if existing := m.accumulated[varName]; existing != "" {
+				m.accumulated[varName] = existing + " " + val
+			} else {
+				m.accumulated[varName] = val
+			}
+		}
+	}
+
+	// Restore backed-up values
+	result := make(map[string]string, len(newEnv))
+	for k, v := range newEnv {
+		result[k] = v
+	}
+
+	for _, varName := range MetadataVars {
+		if backedUp, ok := backup[varName]; ok {
+			result[varName] = backedUp
+		} else {
+			delete(result, varName)
+		}
+	}
+
+	// Record as inherited
+	m.addInherited(eclassName)
+
+	// Clear current eclass
+	if m.depth == 0 {
+		m.currentEclass = ""
+	}
+
+	return result
+}
+
+// addInherited adds an eclass to the inherited list.
+// Must be called with lock held.
+func (m *MetadataManager) addInherited(name string) {
+	for _, existing := range m.inherited {
+		if existing == name {
+			return // Already inherited
+		}
+	}
+	m.inherited = append(m.inherited, name)
+}
+
+// ExportFunctions registers phase functions from the current eclass.
+//
+// Usage: EXPORT_FUNCTIONS src_compile src_install
+func (m *MetadataManager) ExportFunctions(phases []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.currentEclass == "" {
+		return &ExportFunctionsError{Message: "EXPORT_FUNCTIONS called without a defined ECLASS"}
+	}
+
+	for _, phase := range phases {
+		m.exported[phase] = m.currentEclass
+	}
+
+	return nil
+}
+
+// GetExportedFunction returns the eclass that exports a phase function.
+func (m *MetadataManager) GetExportedFunction(phase string) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	eclass, ok := m.exported[phase]
+	return eclass, ok
+}
+
+// GetInherited returns the list of inherited eclasses.
+func (m *MetadataManager) GetInherited() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]string, len(m.inherited))
+	copy(result, m.inherited)
+	return result
+}
+
+// GetInheritedString returns INHERITED as a space-separated string.
+func (m *MetadataManager) GetInheritedString() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return strings.Join(m.inherited, " ")
+}
+
+// IsInherited checks if an eclass has been inherited.
+func (m *MetadataManager) IsInherited(name string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, existing := range m.inherited {
+		if existing == name {
+			return true
+		}
+	}
+	return false
+}
+
+// GetAccumulated returns accumulated metadata.
+func (m *MetadataManager) GetAccumulated() map[string]string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make(map[string]string, len(m.accumulated))
+	for k, v := range m.accumulated {
+		result[k] = v
+	}
+	return result
+}
+
+// GetAccumulatedVar returns a specific accumulated variable.
+func (m *MetadataManager) GetAccumulatedVar(name string) string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.accumulated[name]
+}
+
+// FinalizeMetadata merges accumulated metadata into the environment.
+//
+// For each metadata variable:
+//   - If ebuild defined it: ebuild_value + " " + accumulated_value
+//   - If only eclass defined it: accumulated_value
+func (m *MetadataManager) FinalizeMetadata(env map[string]string) map[string]string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make(map[string]string, len(env))
+	for k, v := range env {
+		result[k] = v
+	}
+
+	for _, varName := range MetadataVars {
+		accValue := m.accumulated[varName]
+		ebuildValue := env[varName]
+
+		if accValue != "" {
+			if ebuildValue != "" {
+				result[varName] = ebuildValue + " " + accValue
+			} else {
+				result[varName] = accValue
+			}
+		}
+	}
+
+	return result
+}
+
+// GetCurrentEclass returns the currently executing eclass.
+func (m *MetadataManager) GetCurrentEclass() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.currentEclass
+}
+
+// GetDepth returns the current nesting depth.
+func (m *MetadataManager) GetDepth() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.depth
+}
+
+// Reset clears all state.
+func (m *MetadataManager) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.accumulated = make(map[string]string)
+	m.exported = make(map[string]string)
+	m.inherited = make([]string, 0)
+	m.currentEclass = ""
+	m.depth = 0
+}
+
+// ExportFunctionsError is returned when EXPORT_FUNCTIONS fails.
+type ExportFunctionsError struct {
+	Message string
+}
+
+func (e *ExportFunctionsError) Error() string {
+	return e.Message
+}
+
+// PhaseFunctionName returns the function name for an exported phase.
+//
+// For phase "src_compile" exported by eclass "cmake", returns "cmake_src_compile".
+func PhaseFunctionName(eclass, phase string) string {
+	return eclass + "_" + phase
+}
+
+// IsPhaseFunction checks if a function name matches the pattern for an exported phase.
+//
+// Returns (eclass, phase, true) if it matches "{eclass}_{phase}" pattern.
+func IsPhaseFunction(funcName string) (eclass, phase string, ok bool) {
+	// Valid phases
+	phases := []string{
+		"pkg_pretend", "pkg_setup", "pkg_nofetch",
+		"src_unpack", "src_prepare", "src_configure",
+		"src_compile", "src_test", "src_install",
+		"pkg_preinst", "pkg_postinst", "pkg_prerm", "pkg_postrm",
+		"pkg_config", "pkg_info",
+	}
+
+	for _, p := range phases {
+		suffix := "_" + p
+		if strings.HasSuffix(funcName, suffix) {
+			return funcName[:len(funcName)-len(suffix)], p, true
+		}
+	}
+
+	return "", "", false
+}

--- a/internal/eclass/metadata_test.go
+++ b/internal/eclass/metadata_test.go
@@ -1,0 +1,288 @@
+package eclass
+
+import (
+	"testing"
+)
+
+func TestNewMetadataManager(t *testing.T) {
+	m := NewMetadataManager()
+	if m == nil {
+		t.Fatal("NewMetadataManager returned nil")
+	}
+
+	if len(m.accumulated) != 0 {
+		t.Error("expected empty accumulated")
+	}
+
+	if len(m.exported) != 0 {
+		t.Error("expected empty exported")
+	}
+
+	if len(m.inherited) != 0 {
+		t.Error("expected empty inherited")
+	}
+}
+
+func TestMetadataManagerInheritFlow(t *testing.T) {
+	m := NewMetadataManager()
+
+	// Simulate ebuild environment
+	env := map[string]string{
+		"P":      "test-1.0",
+		"DEPEND": "ebuild-dep",
+	}
+
+	// Begin inherit
+	backup := m.BeginInherit("test-eclass", env)
+
+	if m.GetCurrentEclass() != "test-eclass" {
+		t.Errorf("expected current eclass 'test-eclass', got '%s'", m.GetCurrentEclass())
+	}
+
+	if m.GetDepth() != 1 {
+		t.Errorf("expected depth 1, got %d", m.GetDepth())
+	}
+
+	// Simulate eclass setting variables
+	eclassEnv := map[string]string{
+		"P":      "test-1.0",
+		"DEPEND": "eclass-dep",
+		"IUSE":   "eclass-flag",
+	}
+
+	// End inherit
+	result := m.EndInherit("test-eclass", eclassEnv, backup)
+
+	// Check inherited
+	if !m.IsInherited("test-eclass") {
+		t.Error("expected test-eclass to be inherited")
+	}
+
+	// Check accumulated
+	accumulated := m.GetAccumulated()
+	if accumulated["DEPEND"] != "eclass-dep" {
+		t.Errorf("expected accumulated DEPEND='eclass-dep', got '%s'", accumulated["DEPEND"])
+	}
+	if accumulated["IUSE"] != "eclass-flag" {
+		t.Errorf("expected accumulated IUSE='eclass-flag', got '%s'", accumulated["IUSE"])
+	}
+
+	// Check restored values
+	if result["DEPEND"] != "ebuild-dep" {
+		t.Errorf("expected restored DEPEND='ebuild-dep', got '%s'", result["DEPEND"])
+	}
+}
+
+func TestMetadataManagerExportFunctions(t *testing.T) {
+	m := NewMetadataManager()
+
+	// Export without ECLASS should fail
+	err := m.ExportFunctions([]string{"src_compile"})
+	if err == nil {
+		t.Error("expected error for EXPORT_FUNCTIONS without ECLASS")
+	}
+
+	// Set current eclass
+	m.mu.Lock()
+	m.currentEclass = "cmake"
+	m.mu.Unlock()
+
+	// Export should succeed
+	err = m.ExportFunctions([]string{"src_compile", "src_install"})
+	if err != nil {
+		t.Fatalf("ExportFunctions failed: %v", err)
+	}
+
+	// Check exported
+	eclass, ok := m.GetExportedFunction("src_compile")
+	if !ok || eclass != "cmake" {
+		t.Errorf("expected src_compile exported by cmake, got %s, %v", eclass, ok)
+	}
+
+	eclass, ok = m.GetExportedFunction("src_install")
+	if !ok || eclass != "cmake" {
+		t.Errorf("expected src_install exported by cmake, got %s, %v", eclass, ok)
+	}
+
+	// Non-exported should return false
+	_, ok = m.GetExportedFunction("src_test")
+	if ok {
+		t.Error("expected src_test to not be exported")
+	}
+}
+
+func TestMetadataManagerMultipleInherits(t *testing.T) {
+	m := NewMetadataManager()
+
+	// First inherit
+	backup1 := m.BeginInherit("eclass1", map[string]string{})
+	env1 := map[string]string{"DEPEND": "dep1", "IUSE": "flag1"}
+	m.EndInherit("eclass1", env1, backup1)
+
+	// Second inherit
+	backup2 := m.BeginInherit("eclass2", map[string]string{})
+	env2 := map[string]string{"DEPEND": "dep2", "IUSE": "flag2"}
+	m.EndInherit("eclass2", env2, backup2)
+
+	// Check both inherited
+	inherited := m.GetInherited()
+	if len(inherited) != 2 {
+		t.Errorf("expected 2 inherited eclasses, got %d", len(inherited))
+	}
+
+	// Check accumulated (should be concatenated)
+	accumulated := m.GetAccumulated()
+	if accumulated["DEPEND"] != "dep1 dep2" {
+		t.Errorf("expected DEPEND='dep1 dep2', got '%s'", accumulated["DEPEND"])
+	}
+	if accumulated["IUSE"] != "flag1 flag2" {
+		t.Errorf("expected IUSE='flag1 flag2', got '%s'", accumulated["IUSE"])
+	}
+}
+
+func TestMetadataManagerFinalizeMetadata(t *testing.T) {
+	m := NewMetadataManager()
+
+	// Simulate inherits
+	backup := m.BeginInherit("test", map[string]string{})
+	m.EndInherit("test", map[string]string{"DEPEND": "eclass-dep"}, backup)
+
+	// Ebuild environment
+	env := map[string]string{
+		"DEPEND": "ebuild-dep",
+		"IUSE":   "ebuild-flag",
+	}
+
+	// Finalize
+	result := m.FinalizeMetadata(env)
+
+	// DEPEND should be ebuild + eclass
+	if result["DEPEND"] != "ebuild-dep eclass-dep" {
+		t.Errorf("expected DEPEND='ebuild-dep eclass-dep', got '%s'", result["DEPEND"])
+	}
+
+	// IUSE should be just ebuild (no eclass value)
+	if result["IUSE"] != "ebuild-flag" {
+		t.Errorf("expected IUSE='ebuild-flag', got '%s'", result["IUSE"])
+	}
+}
+
+func TestMetadataManagerReset(t *testing.T) {
+	m := NewMetadataManager()
+
+	// Add some state
+	m.mu.Lock()
+	m.currentEclass = "test"
+	m.depth = 2
+	m.inherited = append(m.inherited, "test")
+	m.accumulated["DEPEND"] = "dep"
+	m.exported["src_compile"] = "test"
+	m.mu.Unlock()
+
+	// Reset
+	m.Reset()
+
+	// Verify cleared
+	if m.GetCurrentEclass() != "" {
+		t.Error("expected empty current eclass after reset")
+	}
+	if m.GetDepth() != 0 {
+		t.Error("expected depth 0 after reset")
+	}
+	if len(m.GetInherited()) != 0 {
+		t.Error("expected empty inherited after reset")
+	}
+	if len(m.GetAccumulated()) != 0 {
+		t.Error("expected empty accumulated after reset")
+	}
+}
+
+func TestPhaseFunctionName(t *testing.T) {
+	tests := []struct {
+		eclass   string
+		phase    string
+		expected string
+	}{
+		{"cmake", "src_compile", "cmake_src_compile"},
+		{"meson", "src_install", "meson_src_install"},
+		{"python-r1", "pkg_setup", "python-r1_pkg_setup"},
+	}
+
+	for _, tt := range tests {
+		result := PhaseFunctionName(tt.eclass, tt.phase)
+		if result != tt.expected {
+			t.Errorf("PhaseFunctionName(%s, %s) = %s, want %s",
+				tt.eclass, tt.phase, result, tt.expected)
+		}
+	}
+}
+
+func TestIsPhaseFunction(t *testing.T) {
+	tests := []struct {
+		funcName      string
+		expectEclass  string
+		expectPhase   string
+		expectMatched bool
+	}{
+		{"cmake_src_compile", "cmake", "src_compile", true},
+		{"meson_src_install", "meson", "src_install", true},
+		{"python-r1_pkg_setup", "python-r1", "pkg_setup", true},
+		{"random_function", "", "", false},
+		{"src_compile", "", "", false}, // No eclass prefix
+	}
+
+	for _, tt := range tests {
+		eclass, phase, matched := IsPhaseFunction(tt.funcName)
+		if matched != tt.expectMatched {
+			t.Errorf("IsPhaseFunction(%s): matched = %v, want %v",
+				tt.funcName, matched, tt.expectMatched)
+		}
+		if matched {
+			if eclass != tt.expectEclass {
+				t.Errorf("IsPhaseFunction(%s): eclass = %s, want %s",
+					tt.funcName, eclass, tt.expectEclass)
+			}
+			if phase != tt.expectPhase {
+				t.Errorf("IsPhaseFunction(%s): phase = %s, want %s",
+					tt.funcName, phase, tt.expectPhase)
+			}
+		}
+	}
+}
+
+func TestMetadataManagerGetInheritedString(t *testing.T) {
+	m := NewMetadataManager()
+
+	// Empty
+	if m.GetInheritedString() != "" {
+		t.Error("expected empty string for no inherited")
+	}
+
+	// Add some
+	m.mu.Lock()
+	m.inherited = []string{"foo", "bar", "baz"}
+	m.mu.Unlock()
+
+	result := m.GetInheritedString()
+	if result != "foo bar baz" {
+		t.Errorf("expected 'foo bar baz', got '%s'", result)
+	}
+}
+
+func TestMetadataManagerGetAccumulatedVar(t *testing.T) {
+	m := NewMetadataManager()
+
+	// Empty
+	if m.GetAccumulatedVar("DEPEND") != "" {
+		t.Error("expected empty for unset var")
+	}
+
+	// Set
+	m.mu.Lock()
+	m.accumulated["DEPEND"] = "test-dep"
+	m.mu.Unlock()
+
+	if m.GetAccumulatedVar("DEPEND") != "test-dep" {
+		t.Errorf("expected 'test-dep', got '%s'", m.GetAccumulatedVar("DEPEND"))
+	}
+}


### PR DESCRIPTION
## Summary

This PR implements dynamic eclass loading from repository directories, addressing community feedback about hardcoded eclass implementations.

### Key Changes

- **New `internal/eclass/` package** (3300+ lines)
  - `Cache`: Scans eclass/ directories with mtime-based caching
  - `Executor`: Executes eclasses via mvdan.cc/sh interpreter
  - `HybridLoader`: Dynamic loading with Go fallback support
  - `MetadataAccumulator`: Handles DEPEND, IUSE, RDEPEND accumulation

- **Bridge integration** (`internal/ebuild/eclass_bridge.go`)
  - `DynamicEclassLoader`: Adapts eclass package to ebuild interfaces
  - `SetupDynamicEclassLoading()`: Configuration helper

- **Executor integration**
  - New `EnableDynamicEclass` option (true by default)
  - New `EclassLocations` option for custom paths
  - Seamless fallback to Go implementations

### Architecture

```
Priority Order:
1. Dynamic loading from repository eclass/ directories
2. Fallback to Go implementations (cmake, meson, python, cargo, etc.)
```

### Community Feedback

This addresses criticism from [forums.gentoo.org](https://forums.gentoo.org/viewtopic-p-8877844.html#8877844):
> "The package manager shouldn't have copies of those at all."

Now GRPM loads eclasses directly from the repository, matching Portage behavior.

## Test Plan

- [x] All existing tests pass
- [x] Linter passes (0 issues)
- [x] New package has comprehensive tests
- [x] Integration tested with build