### PR TITLE
docs: v0.7.3 Documentation Hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.3] - 2026-01-13
+
+### Documentation Hotfix
+
+> **Documentation and Process Improvements**
+
+#### Fixed
+- **README.md** - REST API endpoint corrected to Unix socket (`/var/run/grpm-rest.sock`)
+- **ROADMAP.md** - Updated to reflect v0.7.2 as current release with 98.2% coverage
+
+#### Changed
+- Release process documentation improved with clear pre-release checklist
+
+---
+
 ## [0.7.2] - 2026-01-13
 
 ### Portage Compatibility Hotfix
@@ -721,7 +736,8 @@ GRPM (Go Resource Package Manager) is a modern reimplementation of Gentoo's Port
 - **Issues**: https://github.com/grpmsoft/grpm/issues
 - **License**: [Apache-2.0](LICENSE)
 
-[Unreleased]: https://github.com/grpmsoft/grpm/compare/v0.7.2...HEAD
+[Unreleased]: https://github.com/grpmsoft/grpm/compare/v0.7.3...HEAD
+[0.7.3]: https://github.com/grpmsoft/grpm/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/grpmsoft/grpm/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/grpmsoft/grpm/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/grpmsoft/grpm/compare/v0.6.0...v0.7.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,10 +1,10 @@
 # GRPM Roadmap
 
-> **Portage Compatibility Hotfix (v0.7.2)**
+> **Documentation Hotfix (v0.7.3)**
 >
 > Rapid development complete (v0.1.0 → v0.5.0).
 > Infrastructure release complete (v0.6.0).
-> Portage-style logging (v0.7.0) + compatibility fixes (v0.7.2).
+> Portage-style logging (v0.7.0) + compatibility fixes (v0.7.2) + docs (v0.7.3).
 > **98.2% tree coverage verified on real Gentoo!**
 
 ---
@@ -137,10 +137,11 @@ Key insight: **Eclasses don't need Go implementations.** They are loaded dynamic
 ## Roadmap to v1.0.0
 
 ```
-v0.7.2 ← CURRENT (Portage Compatibility Hotfix)
+v0.7.3 ← CURRENT (Documentation Hotfix)
     │   ✅ v0.6.0: Distfile fetching, debug helpers, coverage analyzer
     │   ✅ v0.7.0: Portage-style logging
     │   ✅ v0.7.2: package.mask directories, SRC_URI parsing
+    │   ✅ v0.7.3: Documentation fixes
     │   ✅ 98.2% tree coverage on real Gentoo!
     ↓
 v0.8.0 — Production Hardening (2 tasks)


### PR DESCRIPTION
## Summary

Documentation fixes for v0.7.3 release.

### Fixed
- **README.md** - REST API endpoint corrected to Unix socket (`/var/run/grpm-rest.sock`)
- **ROADMAP.md** - Updated to reflect current version (v0.7.3)

### Changed
- **CHANGELOG.md** - Added v0.7.3 release notes

## Test Plan
- [x] Documentation is accurate
- [x] Version numbers are consistent