### PR TITLE
feat(emerge): add --root flag for alternative installation root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`--root` flag for emerge** — Install packages to alternative root directory
+  - Equivalent to `$ROOT` environment variable in Portage
+  - Useful for building stage tarballs, chroots, cross-compilation
+  - VarDB created at `{root}/var/db/pkg`
+  - Example: `grpm emerge --root /mnt/gentoo app-misc/hello`
+
 ### Planned
 - Performance optimization for large dependency graphs
 - Web UI for daemon management

--- a/internal/cli/emerge.go
+++ b/internal/cli/emerge.go
@@ -59,6 +59,7 @@ func (a *App) runEmerge(args []string) error {
 	fs.BoolVar(replace, "R", false, "Alias for --replace")
 	force := fs.Bool("force", false, "Force installation (skip collision checks for untracked files)")
 	fs.BoolVar(force, "f", false, "Alias for --force")
+	rootPath := fs.String("root", "/", "Installation root directory (like $ROOT in Portage)")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -145,6 +146,7 @@ func (a *App) runEmerge(args []string) error {
 		enableTests: *enableTests,
 		replace:     *replace,
 		force:       *force,
+		root:        *rootPath,
 		fetcher:     fetcher,
 	}
 
@@ -154,7 +156,7 @@ func (a *App) runEmerge(args []string) error {
 	}
 
 	// Sequential build (original behavior)
-	return a.buildAndInstallPackages(solution, *repoPath, *distDir, *tmpDir, *makeJobs, *keepWork, *enableTests, *replace, *force, fetcher)
+	return a.buildAndInstallPackages(solution, *repoPath, *distDir, *tmpDir, *makeJobs, *keepWork, *enableTests, *replace, *force, *rootPath, fetcher)
 }
 
 // parallelBuildOptions holds options for parallel build execution.
@@ -167,6 +169,7 @@ type parallelBuildOptions struct {
 	enableTests bool
 	replace     bool
 	force       bool
+	root        string
 	fetcher     fetch.Fetcher
 }
 
@@ -177,14 +180,14 @@ type parallelBuildOptions struct {
 func (a *App) buildPackagesParallel(solution map[string]*pkg.Package, parallelJobs int, keepGoing bool, opts *parallelBuildOptions) error {
 	logging.Action("Starting parallel build with %d workers...", parallelJobs)
 
-	// Get package database
-	db, err := a.getOrCreatePackageDB()
+	// Get package database (with root prefix)
+	db, err := a.getOrCreatePackageDBWithRoot(opts.root)
 	if err != nil {
 		return fmt.Errorf("failed to initialize package database: %w", err)
 	}
 
-	// Create installer
-	installer := install.NewInstaller("/", db)
+	// Create installer with custom root
+	installer := install.NewInstaller(opts.root, db)
 	installer.Verbose = a.verbose
 
 	// Configure scheduler
@@ -408,20 +411,20 @@ func (a *App) createFetcher(distDir string) fetch.Fetcher {
 }
 
 // buildAndInstallPackages builds packages from source and installs them.
-func (a *App) buildAndInstallPackages(solution map[string]*pkg.Package, repoPath, distDir, tmpDir string, jobs int, keepWork, enableTests, replace, force bool, fetcher fetch.Fetcher) error {
+func (a *App) buildAndInstallPackages(solution map[string]*pkg.Package, repoPath, distDir, tmpDir string, jobs int, keepWork, enableTests, replace, force bool, root string, fetcher fetch.Fetcher) error {
 	logging.Action("Starting source build...")
 
 	builtCount := 0
 	totalPackages := len(solution)
 
-	// Get package database
-	db, err := a.getOrCreatePackageDB()
+	// Get package database (with root prefix)
+	db, err := a.getOrCreatePackageDBWithRoot(root)
 	if err != nil {
 		return fmt.Errorf("failed to initialize package database: %w", err)
 	}
 
-	// Create installer
-	installer := install.NewInstaller("/", db)
+	// Create installer with custom root
+	installer := install.NewInstaller(root, db)
 	installer.Verbose = a.verbose
 
 	for name, p := range solution {

--- a/internal/cli/emerge_test.go
+++ b/internal/cli/emerge_test.go
@@ -190,3 +190,79 @@ func TestCreateFetcher(t *testing.T) {
 		t.Error("Expected *fetch.HTTPDownloader")
 	}
 }
+
+func TestGetOrCreatePackageDBWithRoot(t *testing.T) {
+	t.Run("creates VarDB in custom root", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		app := &App{verbose: false}
+
+		db, err := app.getOrCreatePackageDBWithRoot(tmpDir)
+		if err != nil {
+			t.Fatalf("getOrCreatePackageDBWithRoot failed: %v", err)
+		}
+		if db == nil {
+			t.Fatal("returned nil database")
+		}
+
+		// Verify VarDB directory was created
+		vardbPath := filepath.Join(tmpDir, "var/db/pkg")
+		if _, err := os.Stat(vardbPath); os.IsNotExist(err) {
+			t.Errorf("VarDB directory not created at %s", vardbPath)
+		}
+	})
+
+	t.Run("default root uses /var/db/pkg", func(t *testing.T) {
+		app := &App{verbose: false}
+
+		// This test verifies the getOrCreatePackageDB uses "/" as default
+		// We can't actually test writing to /var/db/pkg without root permissions
+		// so we just verify the function doesn't panic
+		_, _ = app.getOrCreatePackageDB()
+		// No assertion needed - just verify it doesn't crash
+	})
+
+	t.Run("handles nested root paths", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		nestedRoot := filepath.Join(tmpDir, "chroot", "gentoo")
+		app := &App{verbose: false}
+
+		db, err := app.getOrCreatePackageDBWithRoot(nestedRoot)
+		if err != nil {
+			t.Fatalf("getOrCreatePackageDBWithRoot failed: %v", err)
+		}
+		if db == nil {
+			t.Fatal("returned nil database")
+		}
+
+		// Verify nested VarDB directory was created
+		vardbPath := filepath.Join(nestedRoot, "var/db/pkg")
+		if _, err := os.Stat(vardbPath); os.IsNotExist(err) {
+			t.Errorf("VarDB directory not created at %s", vardbPath)
+		}
+	})
+}
+
+func TestParallelBuildOptionsRoot(t *testing.T) {
+	t.Run("root field is set in options", func(t *testing.T) {
+		opts := &parallelBuildOptions{
+			repoPath: "/var/db/repos/gentoo",
+			distDir:  "/var/cache/distfiles",
+			tmpDir:   "/var/tmp/portage",
+			root:     "/mnt/gentoo",
+		}
+
+		if opts.root != "/mnt/gentoo" {
+			t.Errorf("Expected root /mnt/gentoo, got %s", opts.root)
+		}
+	})
+
+	t.Run("default root is /", func(t *testing.T) {
+		opts := &parallelBuildOptions{
+			root: "/",
+		}
+
+		if opts.root != "/" {
+			t.Errorf("Expected root /, got %s", opts.root)
+		}
+	})
+}

--- a/internal/cli/install_real.go
+++ b/internal/cli/install_real.go
@@ -231,9 +231,18 @@ func (a *App) createMockFiles(imageDir string, p *pkg.Package) error {
 }
 
 // getOrCreatePackageDB returns the package database, creating it if needed.
+// Uses the default root "/".
 func (a *App) getOrCreatePackageDB() (*state.PackageDatabase, error) {
+	return a.getOrCreatePackageDBWithRoot("/")
+}
+
+// getOrCreatePackageDBWithRoot returns the package database with a custom root.
+// The VarDB path will be {root}/var/db/pkg.
+func (a *App) getOrCreatePackageDBWithRoot(root string) (*state.PackageDatabase, error) {
+	// Build VarDB path with root prefix
+	vardbPath := filepath.Join(root, "var/db/pkg")
+
 	// Check if VarDB exists
-	vardbPath := "/var/db/pkg"
 	if _, err := os.Stat(vardbPath); os.IsNotExist(err) {
 		// Create VarDB directory structure
 		if err := os.MkdirAll(vardbPath, 0755); err != nil {
@@ -252,7 +261,7 @@ func (a *App) getOrCreatePackageDB() (*state.PackageDatabase, error) {
 	}
 
 	if a.verbose {
-		logging.Debug("Package database initialized with %d packages", db.Count())
+		logging.Debug("Package database initialized with %d packages (root: %s)", db.Count(), root)
 	}
 
 	return db, nil


### PR DESCRIPTION
## Summary

- Add `--root` flag to emerge command (equivalent to `$ROOT` in Portage)
- VarDB created at `{root}/var/db/pkg`
- Useful for: stage tarballs, chroots, cross-compilation

## Usage

```bash
grpm emerge --root /mnt/gentoo app-misc/hello
```

## Test plan

- [x] Unit tests for `getOrCreatePackageDBWithRoot()`
- [x] Unit tests for `parallelBuildOptions.root`
- [x] All existing tests pass
- [ ] Manual testing on Gentoo (user requested feature)