### PR TITLE
fix: versioned atom parsing in resolver (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.9] - 2026-01-16
+
+### Versioned Atom Support
+
+> **Fix for Issue #30: emerge now correctly handles versioned atoms**
+>
+> Commands like `grpm emerge "=sys-devel/gcc-13.4.1_p20250807"` now work as expected.
+
+### Fixed
+- **Versioned atom parsing in resolver** — Atoms with version operators (`=`, `>=`, `<`, etc.) are now properly parsed before package lookup ([#30](https://github.com/grpmsoft/grpm/issues/30))
+  - Previously: `=sys-devel/gcc-13.4.1_p20250807` was passed directly to filesystem, causing "no such file or directory"
+  - Now: Atom is parsed, `category/package` extracted, version constraint applied via `FindByAtom()`
+
+### Added
+- `loadPackageFromAtom()` helper in resolver for PMS-compliant atom parsing
+- Regression tests for versioned atom handling (`resolver_test.go`)
+
+### Technical Details
+- `internal/solver/resolver.go` — New `loadPackageFromAtom()` function, modified `Resolve()` to track root package names
+- `internal/solver/resolver_test.go` — 3 new test functions covering Issue #30 scenarios
+
+---
+
 ## [0.7.8] - 2026-01-14
 
 ### Alternative Root Installation

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ grpm fetch app-misc/hello
 # Build from source (auto-fetches sources)
 sudo grpm emerge app-misc/hello
 
+# Build specific version (PMS-compliant atoms)
+sudo grpm emerge "=sys-devel/gcc-13.4.1_p20250807"
+sudo grpm emerge ">=dev-libs/openssl-3.0"
+
 # Build to alternative root (chroot, stage tarball)
 sudo grpm emerge --root /mnt/gentoo app-misc/hello
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # GRPM Roadmap
 
-> **Alternative Root Installation (v0.7.8)**
+> **Versioned Atom Support (v0.7.9)**
 >
 > Rapid development complete (v0.1.0 → v0.5.0).
 > Infrastructure release complete (v0.6.0).
@@ -9,6 +9,7 @@
 > Critical version selection bug fix + emerge flags (v0.7.6).
 > Professional E2E test suite with CI integration (v0.7.7).
 > `--root` flag for chroot/stage tarball builds (v0.7.8).
+> Versioned atom support: `=pkg-1.0`, `>=pkg-2.0` (v0.7.9).
 > **98.2% tree coverage verified on real Gentoo!**
 
 ---
@@ -69,7 +70,15 @@ Key insight: **Eclasses don't need Go implementations.** They are loaded dynamic
 
 ## Release History
 
-### v0.7.8 — Alternative Root Installation (Current)
+### v0.7.9 — Versioned Atom Support (Current)
+
+**Fix for Issue #30: emerge now correctly handles versioned atoms:**
+
+- **Atom parsing** — `=sys-devel/gcc-13.4.1_p20250807`, `>=dev-libs/openssl-3.0` now work correctly
+- **PMS compliance** — Full support for version operators (`=`, `>=`, `>`, `<=`, `<`, `~`, `=*`)
+- **Regression tests** — Comprehensive test coverage for atom parsing edge cases
+
+### v0.7.8 — Alternative Root Installation
 
 **Install packages to chroot, stage tarballs, or cross-compilation targets:**
 

--- a/internal/solver/resolver.go
+++ b/internal/solver/resolver.go
@@ -2,6 +2,7 @@ package solver
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/grpmsoft/grpm/internal/logging"
 	"github.com/grpmsoft/grpm/internal/pkg"
@@ -129,16 +130,63 @@ func (r *PortageResolver) buildResultFromSolution(solution map[string]string) (m
 	return result, nil
 }
 
+// loadPackageFromAtom parses a package atom string and loads the matching package.
+// Supports PMS-compliant atoms like "=sys-devel/gcc-13.4.1_p20250807" or ">=dev-libs/openssl-3.0".
+// If no version operator is specified, loads the highest available version.
+func (r *PortageResolver) loadPackageFromAtom(atomStr string) (*pkg.Package, error) {
+	// Try to parse as a full atom first
+	atom, err := pkg.ParseAtom(atomStr)
+	if err != nil {
+		// If parsing fails, it might be a simple "category/package" string
+		// Try loading directly
+		return r.repo.LoadPackage(atomStr)
+	}
+
+	// If atom has a version constraint, use FindByAtom to get matching packages
+	if atom.HasVersion() {
+		matches, err := r.repo.FindByAtom(atom)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find packages matching %s: %w", atomStr, err)
+		}
+
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("no packages match atom %s", atomStr)
+		}
+
+		// Sort matches by version (highest first) and return the best match
+		sort.Slice(matches, func(i, j int) bool {
+			return pkg.CompareVersions(matches[i].Version, matches[j].Version) > 0
+		})
+
+		// For exact match (=), return the only match
+		// For range operators (>=, >, <=, <), return the highest matching version
+		// For ~ (revision match), return the highest matching revision
+		logging.Debug("Atom %s matched %d packages, selected %s-%s",
+			atomStr, len(matches), matches[0].Name, matches[0].Version)
+
+		return matches[0], nil
+	}
+
+	// No version constraint - load package by category/package name
+	return r.repo.LoadPackage(atom.CP())
+}
+
 func (r *PortageResolver) Resolve(packages []string) (map[string]*pkg.Package, error) {
 	adapter := NewGophersatAdapter()
 	allPackages := make(map[string]*pkg.Package)
 
+	// Track root package names (not atom strings) for constraint generation
+	rootPackageNames := make([]string, 0, len(packages))
+
 	// Load and collect all dependencies
 	for _, pkgName := range packages {
-		p, err := r.repo.LoadPackage(pkgName)
+		p, err := r.loadPackageFromAtom(pkgName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load package %s: %w", pkgName, err)
 		}
+
+		// Store the actual package name (category/package) for constraints
+		rootPackageNames = append(rootPackageNames, p.Name)
 
 		logging.Debug("Resolving package: %s-%s with %d dependencies",
 			p.Name, p.Version, len(p.Deps))
@@ -155,9 +203,9 @@ func (r *PortageResolver) Resolve(packages []string) (map[string]*pkg.Package, e
 		adapter.AddPackage(p)
 	}
 
-	// Then add constraints for each package
+	// Then add constraints for each package using actual package names
 	for _, p := range allPackages {
-		r.addPackageConstraints(adapter, p, packages)
+		r.addPackageConstraints(adapter, p, rootPackageNames)
 	}
 
 	logging.Debug("Total clauses in SAT problem: %d", len(adapter.clauses))

--- a/internal/solver/resolver_test.go
+++ b/internal/solver/resolver_test.go
@@ -1,0 +1,142 @@
+package solver
+
+import (
+	"testing"
+
+	"github.com/grpmsoft/grpm/internal/pkg"
+	"github.com/grpmsoft/grpm/internal/repo"
+)
+
+// TestResolveVersionedAtom tests that Resolve correctly handles versioned atoms.
+// This is a regression test for Issue #30 where atoms like "=sys-devel/gcc-13.4.1"
+// were passed directly to LoadPackage(), causing "no such file or directory" errors.
+func TestResolveVersionedAtom(t *testing.T) {
+	// Create mock repository with the exact version we're looking for
+	mockRepo := repo.NewEmptyMockRepository()
+
+	// Add package with version similar to Issue #30
+	gcc := pkg.NewPackage("sys-devel/gcc", "13.4.1_p20250807", "13")
+	mockRepo.Add(gcc)
+
+	resolver := NewResolver(mockRepo)
+
+	tests := []struct {
+		name        string
+		atomStr     string
+		wantName    string
+		wantVersion string
+		wantErr     bool
+	}{
+		{
+			// This is the exact case from Issue #30
+			name:        "exact version with = operator (Issue #30)",
+			atomStr:     "=sys-devel/gcc-13.4.1_p20250807",
+			wantName:    "sys-devel/gcc",
+			wantVersion: "13.4.1_p20250807",
+			wantErr:     false,
+		},
+		{
+			name:        "simple category/package",
+			atomStr:     "sys-devel/gcc",
+			wantName:    "sys-devel/gcc",
+			wantVersion: "13.4.1_p20250807",
+			wantErr:     false,
+		},
+		{
+			name:        "greater-equal constraint matching",
+			atomStr:     ">=sys-devel/gcc-13.0.0",
+			wantName:    "sys-devel/gcc",
+			wantVersion: "13.4.1_p20250807",
+			wantErr:     false,
+		},
+		{
+			name:    "greater-equal constraint NOT matching",
+			atomStr: ">=sys-devel/gcc-99.0.0",
+			wantErr: true,
+		},
+		{
+			name:    "non-existent package",
+			atomStr: "non-existent/package",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := resolver.Resolve([]string{tt.atomStr})
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Resolve(%q) expected error, got nil", tt.atomStr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Resolve(%q) unexpected error: %v", tt.atomStr, err)
+				return
+			}
+
+			p, ok := result[tt.wantName]
+			if !ok {
+				t.Errorf("Resolve(%q) missing package %s in result", tt.atomStr, tt.wantName)
+				return
+			}
+
+			if p.Version != tt.wantVersion {
+				t.Errorf("Resolve(%q) version = %q, want %q",
+					tt.atomStr, p.Version, tt.wantVersion)
+			}
+		})
+	}
+}
+
+// TestResolveWithMockRepositoryVersionedAtom tests Resolve with versioned atoms
+// using the built-in MockRepository which has hello-2.10 version.
+func TestResolveWithMockRepositoryVersionedAtom(t *testing.T) {
+	mockRepo := repo.NewMockRepository()
+	resolver := NewResolver(mockRepo)
+
+	// Test resolving with exact version atom for existing hello-2.10
+	result, err := resolver.Resolve([]string{"=app-misc/hello-2.10"})
+	if err != nil {
+		t.Fatalf("Resolve with versioned atom failed: %v", err)
+	}
+
+	// Should have hello and its dependency zlib
+	if len(result) < 1 {
+		t.Errorf("Expected at least 1 package in result, got %d", len(result))
+	}
+
+	if p, ok := result["app-misc/hello"]; !ok {
+		t.Error("Expected app-misc/hello in result")
+	} else if p.Version != "2.10" {
+		t.Errorf("Expected version 2.10, got %s", p.Version)
+	}
+}
+
+// TestResolveVersionedAtomPathNotTreatedAsDirectory verifies that versioned atoms
+// like "=sys-devel/gcc-13.4.1_p20250807" are not passed directly to the filesystem.
+// This is the core fix for Issue #30.
+func TestResolveVersionedAtomPathNotTreatedAsDirectory(t *testing.T) {
+	mockRepo := repo.NewEmptyMockRepository()
+
+	// Add a package
+	hello := pkg.NewPackage("app-misc/hello", "2.12.1", "0")
+	mockRepo.Add(hello)
+
+	resolver := NewResolver(mockRepo)
+
+	// The bug in Issue #30 was that "=app-misc/hello-2.12.1" was passed
+	// directly to LoadPackage, which treated "=app-misc" as a category name.
+	// The fix parses the atom first, extracts "app-misc/hello" and version "2.12.1".
+
+	result, err := resolver.Resolve([]string{"=app-misc/hello-2.12.1"})
+	if err != nil {
+		t.Fatalf("Resolve should not fail for valid versioned atom: %v", err)
+	}
+
+	if _, ok := result["app-misc/hello"]; !ok {
+		t.Error("Expected app-misc/hello in result")
+	}
+}


### PR DESCRIPTION
## Summary

- Fix Issue #30: `grpm emerge "=sys-devel/gcc-13.4.1_p20250807"` now works correctly
- Add `loadPackageFromAtom()` helper for PMS-compliant atom parsing
- Support version operators: `=`, `>=`, `>`, `<=`, `<`, `~`, `=*`

## Root Cause

The `Resolve()` function passed raw atom strings directly to `LoadPackage()`, which expected only `category/package` format. This caused the repository to try opening paths like `/var/db/repos/gentoo/=sys-devel/gcc-13.4.1_p20250807`.

## Fix

1. Parse input as atom using `pkg.ParseAtom()`
2. Use `FindByAtom()` for versioned atoms
3. Track actual package names for SAT constraint generation

## Test Plan

- [x] Unit tests pass (`go test ./internal/solver/...`)
- [x] New regression tests in `resolver_test.go`
- [x] Linter passes (`golangci-lint run`)
- [ ] CI passes

Closes #30