### PR TITLE
feat(emerge): add --onlydeps flag for Docker layer caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.10] - 2026-01-17
+
+### Docker Layer Caching Support
+
+> **Build dependencies separately for optimized Docker builds**
+>
+> Requested by community ([#33](https://github.com/grpmsoft/grpm/issues/33)) for Docker layer caching optimization.
+
+### Added
+- **`--onlydeps` / `-o` flag for emerge** — Build dependencies only, skip target package(s)
+  - Useful for Docker layer caching: pre-build dependencies in a separate layer
+  - Example: `grpm emerge --onlydeps app-misc/hello` builds only hello's dependencies
+  - Compatible with versioned atoms: `grpm emerge -o "=sys-devel/gcc-13.4.1"`
+  - Portage-compatible behavior (same as `emerge --onlydeps`)
+
+### Technical Details
+- `internal/cli/emerge.go` — Added `--onlydeps` flag and `filterTargetPackages()` function
+- `internal/cli/emerge_test.go` — 6 test cases for atom filtering
+
+---
+
 ## [0.7.9] - 2026-01-16
 
 ### Versioned Atom Support

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ sudo grpm emerge ">=dev-libs/openssl-3.0"
 # Build to alternative root (chroot, stage tarball)
 sudo grpm emerge --root /mnt/gentoo app-misc/hello
 
+# Build dependencies only (useful for Docker layer caching)
+sudo grpm emerge --onlydeps app-misc/hello
+
 # Install from binary
 sudo grpm install --binpkg app-misc/hello
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # GRPM Roadmap
 
-> **Versioned Atom Support (v0.7.9)**
+> **Docker Layer Caching Support (v0.7.10)**
 >
 > Rapid development complete (v0.1.0 → v0.5.0).
 > Infrastructure release complete (v0.6.0).
@@ -10,6 +10,7 @@
 > Professional E2E test suite with CI integration (v0.7.7).
 > `--root` flag for chroot/stage tarball builds (v0.7.8).
 > Versioned atom support: `=pkg-1.0`, `>=pkg-2.0` (v0.7.9).
+> `--onlydeps` flag for Docker layer caching (v0.7.10).
 > **98.2% tree coverage verified on real Gentoo!**
 
 ---
@@ -70,7 +71,15 @@ Key insight: **Eclasses don't need Go implementations.** They are loaded dynamic
 
 ## Release History
 
-### v0.7.9 — Versioned Atom Support (Current)
+### v0.7.10 — Docker Layer Caching (Current)
+
+**Build dependencies separately for optimized Docker builds:**
+
+- **`--onlydeps` / `-o` flag** — Build dependencies only, skip target package(s) ([#33](https://github.com/grpmsoft/grpm/issues/33))
+- **Docker optimization** — Pre-build dependencies in a separate layer for better caching
+- **Portage compatible** — Same behavior as `emerge --onlydeps`
+
+### v0.7.9 — Versioned Atom Support
 
 **Fix for Issue #30: emerge now correctly handles versioned atoms:**
 
@@ -178,7 +187,7 @@ Key insight: **Eclasses don't need Go implementations.** They are loaded dynamic
 ## Roadmap to v1.0.0
 
 ```
-v0.7.8 ← CURRENT (Alternative Root Installation)
+v0.7.10 ← CURRENT (Docker Layer Caching)
     │   ✅ v0.6.0: Distfile fetching, debug helpers, coverage analyzer
     │   ✅ v0.7.0: Portage-style logging
     │   ✅ v0.7.2-v0.7.4: Portage compatibility fixes
@@ -186,6 +195,8 @@ v0.7.8 ← CURRENT (Alternative Root Installation)
     │   ✅ v0.7.6: Version selection fix, emerge flags
     │   ✅ v0.7.7: E2E tests + CI integration
     │   ✅ v0.7.8: --root flag for chroot/stage builds
+    │   ✅ v0.7.9: Versioned atom support
+    │   ✅ v0.7.10: --onlydeps flag for Docker caching
     │   ✅ 98.2% tree coverage on real Gentoo!
     ↓
 v0.8.0 — Production Hardening (2 tasks)
@@ -316,4 +327,4 @@ Key deliverables:
 ---
 
 *This roadmap evolves based on community feedback and project needs.*
-*Last updated: 2026-01-14 (v0.7.8 release)*
+*Last updated: 2026-01-17 (v0.7.10 release)*

--- a/internal/cli/emerge.go
+++ b/internal/cli/emerge.go
@@ -60,6 +60,8 @@ func (a *App) runEmerge(args []string) error {
 	force := fs.Bool("force", false, "Force installation (skip collision checks for untracked files)")
 	fs.BoolVar(force, "f", false, "Alias for --force")
 	rootPath := fs.String("root", "/", "Installation root directory (like $ROOT in Portage)")
+	onlyDeps := fs.Bool("onlydeps", false, "Build dependencies only, not the target package(s)")
+	fs.BoolVar(onlyDeps, "o", false, "Alias for --onlydeps")
 
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -93,6 +95,15 @@ func (a *App) runEmerge(args []string) error {
 	solution, err := a.resolvePackageDependencies(r, packages)
 	if err != nil {
 		return err
+	}
+
+	// Filter out target packages if --onlydeps is specified
+	if *onlyDeps {
+		solution = a.filterTargetPackages(solution, packages)
+		if len(solution) == 0 {
+			logging.Info("No dependencies to build (--onlydeps specified)")
+			return nil
+		}
 	}
 
 	if len(solution) == 0 {
@@ -576,6 +587,38 @@ func (a *App) findEbuildFile(p *pkg.Package, repoPath string) string {
 	}
 
 	return ""
+}
+
+// filterTargetPackages removes the target packages from the solution,
+// leaving only their dependencies. Used for --onlydeps flag.
+//
+// The packages parameter contains atom strings (e.g., "app-misc/hello", "=sys-devel/gcc-13.4.1").
+// Each atom is parsed to extract the package name (category/package), and matching
+// packages are removed from the solution.
+func (a *App) filterTargetPackages(solution map[string]*pkg.Package, packages []string) map[string]*pkg.Package {
+	// Build a set of target package names from atoms
+	targetNames := make(map[string]bool)
+	for _, atomStr := range packages {
+		atom, err := pkg.ParseAtom(atomStr)
+		if err != nil {
+			// If parsing fails, try using the string directly as package name
+			targetNames[atomStr] = true
+			continue
+		}
+		targetNames[atom.CP()] = true
+	}
+
+	// Filter out target packages
+	filtered := make(map[string]*pkg.Package)
+	for name, p := range solution {
+		if !targetNames[name] {
+			filtered[name] = p
+		} else if a.verbose {
+			logging.Debug("--onlydeps: excluding target package %s-%s", name, p.Version)
+		}
+	}
+
+	return filtered
 }
 
 // checkBuildTools verifies that all required external tools are available.

--- a/internal/cli/emerge_test.go
+++ b/internal/cli/emerge_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grpmsoft/grpm/internal/config"
 	"github.com/grpmsoft/grpm/internal/fetch"
+	"github.com/grpmsoft/grpm/internal/pkg"
 )
 
 func TestParseJobsFromMakeOpts(t *testing.T) {
@@ -265,4 +266,110 @@ func TestParallelBuildOptionsRoot(t *testing.T) {
 			t.Errorf("Expected root /, got %s", opts.root)
 		}
 	})
+}
+
+func TestFilterTargetPackages(t *testing.T) {
+	app := &App{verbose: false}
+
+	// Create test packages
+	hello := pkg.NewPackage("app-misc/hello", "2.10", "0")
+	zlib := pkg.NewPackage("sys-libs/zlib", "1.3", "0")
+	gcc := pkg.NewPackage("sys-devel/gcc", "13.4.1_p20250807", "13")
+
+	tests := []struct {
+		name             string
+		solution         map[string]*pkg.Package
+		packages         []string
+		wantLen          int
+		shouldBeFiltered []string
+		shouldRemain     []string
+	}{
+		{
+			name: "filter simple package name",
+			solution: map[string]*pkg.Package{
+				"app-misc/hello": hello,
+				"sys-libs/zlib":  zlib,
+			},
+			packages:         []string{"app-misc/hello"},
+			wantLen:          1,
+			shouldBeFiltered: []string{"app-misc/hello"},
+			shouldRemain:     []string{"sys-libs/zlib"},
+		},
+		{
+			name: "filter versioned atom",
+			solution: map[string]*pkg.Package{
+				"sys-devel/gcc": gcc,
+				"sys-libs/zlib": zlib,
+			},
+			packages:         []string{"=sys-devel/gcc-13.4.1_p20250807"},
+			wantLen:          1,
+			shouldBeFiltered: []string{"sys-devel/gcc"},
+			shouldRemain:     []string{"sys-libs/zlib"},
+		},
+		{
+			name: "filter multiple packages",
+			solution: map[string]*pkg.Package{
+				"app-misc/hello": hello,
+				"sys-libs/zlib":  zlib,
+				"sys-devel/gcc":  gcc,
+			},
+			packages:         []string{"app-misc/hello", "sys-devel/gcc"},
+			wantLen:          1,
+			shouldBeFiltered: []string{"app-misc/hello", "sys-devel/gcc"},
+			shouldRemain:     []string{"sys-libs/zlib"},
+		},
+		{
+			name: "filter with >= operator",
+			solution: map[string]*pkg.Package{
+				"sys-devel/gcc": gcc,
+				"sys-libs/zlib": zlib,
+			},
+			packages:         []string{">=sys-devel/gcc-13.0.0"},
+			wantLen:          1,
+			shouldBeFiltered: []string{"sys-devel/gcc"},
+			shouldRemain:     []string{"sys-libs/zlib"},
+		},
+		{
+			name: "all packages filtered",
+			solution: map[string]*pkg.Package{
+				"app-misc/hello": hello,
+			},
+			packages:         []string{"app-misc/hello"},
+			wantLen:          0,
+			shouldBeFiltered: []string{"app-misc/hello"},
+			shouldRemain:     []string{},
+		},
+		{
+			name: "no packages filtered (target not in solution)",
+			solution: map[string]*pkg.Package{
+				"sys-libs/zlib": zlib,
+			},
+			packages:         []string{"app-misc/hello"},
+			wantLen:          1,
+			shouldBeFiltered: []string{},
+			shouldRemain:     []string{"sys-libs/zlib"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := app.filterTargetPackages(tt.solution, tt.packages)
+
+			if len(result) != tt.wantLen {
+				t.Errorf("filterTargetPackages() returned %d packages, want %d", len(result), tt.wantLen)
+			}
+
+			for _, name := range tt.shouldBeFiltered {
+				if _, exists := result[name]; exists {
+					t.Errorf("filterTargetPackages() should have filtered %s, but it remains", name)
+				}
+			}
+
+			for _, name := range tt.shouldRemain {
+				if _, exists := result[name]; !exists {
+					t.Errorf("filterTargetPackages() should have kept %s, but it was filtered", name)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Implements `--onlydeps` / `-o` flag for emerge command, allowing users to build only dependencies without the target package(s).

**Closes #33**

## Features

- **`--onlydeps` / `-o` flag** — Build dependencies only, skip target package(s)
- **Docker optimization** — Pre-build dependencies in a separate layer for better caching
- **Portage compatible** — Same behavior as `emerge --onlydeps`
- **Versioned atom support** — Works with `=pkg-1.0`, `>=pkg-2.0`, etc.

## Example Usage

```bash
# Dockerfile for optimized layer caching
FROM gentoo/stage3

# Layer 1: dependencies only (cached)
RUN grpm emerge --onlydeps app-misc/myapp

# Layer 2: application (rebuilds on code change)
COPY . /app
RUN grpm emerge app-misc/myapp
```

## Test Plan

- [x] Unit tests for `filterTargetPackages()` (6 test cases)
- [x] Tested on Gentoo WSL2 with real packages
- [x] Verified with versioned atoms
- [x] Verified `-o` alias works

## Changes

- `internal/cli/emerge.go` — Added flag and filtering logic
- `internal/cli/emerge_test.go` — Added test cases
- `CHANGELOG.md` — Added v0.7.10 section
- `README.md` — Added usage example
- `ROADMAP.md` — Updated for v0.7.10