### PR TITLE
fix: use PORTDIR from make.conf for default repository path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Repository path detection** ([#41](https://github.com/grpmsoft/grpm/issues/41)) — Commands now use `make.conf` PORTDIR instead of hardcoded `/var/db/repos/gentoo`
+  - Affected commands: `search`, `info`, `update`
+  - Users with non-standard repository locations can now use GRPM without `--repo` flag
+
 ### Planned
 - Performance optimization for large dependency graphs
 - Web UI for daemon management

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -14,9 +14,12 @@ import (
 
 // runSearch handles the 'search' command
 func (a *App) runSearch(args []string) error {
+	// Load Portage configuration for default paths
+	cfg := a.loadPortageConfig()
+
 	// Parse flags
 	fs := flag.NewFlagSet("search", flag.ContinueOnError)
-	repoPath := fs.String("repo", "/var/db/repos/gentoo", "Path to Portage repository")
+	repoPath := fs.String("repo", cfg.GetPortDir(), "Path to Portage repository")
 	useMock := fs.Bool("mock", false, "Use mock repository for testing")
 	description := fs.Bool("desc", false, "Search in descriptions too")
 	fs.BoolVar(description, "S", false, "Alias for --desc")
@@ -111,9 +114,12 @@ func (a *App) runSearch(args []string) error {
 
 // runInfo handles the 'info' command
 func (a *App) runInfo(args []string) error {
+	// Load Portage configuration for default paths
+	cfg := a.loadPortageConfig()
+
 	// Parse flags
 	fs := flag.NewFlagSet("info", flag.ContinueOnError)
-	repoPath := fs.String("repo", "/var/db/repos/gentoo", "Path to Portage repository")
+	repoPath := fs.String("repo", cfg.GetPortDir(), "Path to Portage repository")
 	useMock := fs.Bool("mock", false, "Use mock repository for testing")
 
 	if err := fs.Parse(args); err != nil {
@@ -197,9 +203,12 @@ func (a *App) runInfo(args []string) error {
 //   - --pretend/-p: Show what would be updated (dry-run)
 //   - --ask/-a: Ask for confirmation before updating
 func (a *App) runUpdate(args []string) error {
+	// Load Portage configuration for default paths
+	cfg := a.loadPortageConfig()
+
 	// Parse flags
 	fs := flag.NewFlagSet("update", flag.ContinueOnError)
-	repoPath := fs.String("repo", "/var/db/repos/gentoo", "Path to Portage repository")
+	repoPath := fs.String("repo", cfg.GetPortDir(), "Path to Portage repository")
 	useMock := fs.Bool("mock", false, "Use mock repository for testing")
 	pretend := fs.Bool("pretend", false, "Show what would be updated (dry-run)")
 	fs.BoolVar(pretend, "p", false, "Alias for --pretend")


### PR DESCRIPTION
## Summary

Fixes #41 (Phase 1)

Commands now use `cfg.GetPortDir()` instead of hardcoded `/var/db/repos/gentoo`:
- `search`
- `info`
- `update`

This allows users with non-standard repository locations (e.g., `/usr/portage`) to use GRPM without specifying `--repo` flag.

## Changes

- `internal/cli/commands.go`: Load Portage config at start of each command function
- `CHANGELOG.md`: Document the fix

## Test plan

- [x] All existing tests pass
- [x] `golangci-lint` reports 0 issues
- [ ] Manual test on system with custom PORTDIR

## Notes

Phase 2 (full repos.conf support) planned for v0.8.0 — see Issue #41 for details.

---

*Credit: FisHlaBsoMAN, Evgeniy Pichuzhkin (Gentoo Telegram)*